### PR TITLE
ログイン前のヘッダー作成

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -4,9 +4,66 @@
 
 @layer base {
   body {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
     background-color: #F1F1F2;
     color: #333;
     font-size: 16px;
     font-weight: 500;
+  }
+}
+
+@layer components {
+  .header-btn {
+    display: inline-block;
+    position: relative;
+    width: 56px;
+    height: 100%;
+  }
+
+  .header-btn span {
+    display: inline-block;
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 24px;
+    height: 2px;
+    background-color: #fff;
+    transition: all 0.3s;
+  }
+
+  .header-btn span:nth-child(1) {
+    top: calc(50% - 8px);
+  }
+
+  .header-btn span:nth-child(2) {
+    top: 50%;
+  }
+
+  .header-btn span:nth-child(3) {
+    top: calc(50% + 8px);
+  }
+
+  .header-btn.is-open span {
+    left: 40%;
+  }
+
+  .header-btn.is-open span:nth-child(1) {
+    top: calc(50% + 9px);
+    rotate: 45deg;
+  }
+
+  .header-btn.is-open span:nth-child(2) {
+    opacity: 0;
+  }
+
+  .header-btn.is-open span:nth-child(3) {
+    top: calc(50% - 8px);
+    rotate: -45deg;
+  }
+
+  .js-header-menu.is-open {
+    transform: translateX(0);
   }
 }

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,4 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+import "./script.js"

--- a/app/javascript/script.js
+++ b/app/javascript/script.js
@@ -1,0 +1,6 @@
+const headerBtn = document.querySelector(".js-header-btn");
+const headerMenu = document.querySelector(".js-header-menu");
+headerBtn.addEventListener("click", () => {
+  headerBtn.classList.toggle("is-open");
+  headerMenu.classList.toggle("is-open");
+});

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,11 @@
   </head>
 
   <body>
-    <%= yield %>
+    <%= render 'shared/before_login_header' %>
+
+    <main class="flex-1">
+      <%= yield %>
+    </main>
 
     <%= render 'shared/footer' %>
   </body>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,0 +1,34 @@
+<header class="flex justify-between items-center sticky top-0 left-0 z-50 h-14 pl-5 bg-sub-color shadow-md md:h-16 md:px-5">
+  <h1 class="h-full">
+    <%= link_to 'CodeSheet', root_path, class: 'flex items-center h-full text-white text-2xl font-bold md:text-4xl' %>
+  </h1>
+  <nav class="hidden h-full md:block">
+    <ul class="flex gap-5 h-full">
+      <li class="h-full">
+        <%= link_to 'コード一覧', '', class: 'flex items-center h-full text-white hover:underline' %>
+      </li>
+      <li class="h-full">
+        <%= link_to '新規登録', '', class: 'flex items-center h-full text-white hover:underline' %>
+      </li>
+      <li class="h-full">
+        <%= link_to 'ログイン', '', class: 'flex items-center h-full text-white hover:underline' %>
+      </li>
+    </ul>
+  </nav>
+  <button type="button" class="header-btn js-header-btn md:hidden">
+    <span></span>
+    <span></span>
+    <span></span>
+  </button>
+  <ul class="flex flex-col gap-1 fixed top-14 right-0 translate-x-40 z-50 w-36 py-3 bg-sub-color duration-300 js-header-menu">
+    <li>
+      <%= link_to 'コード一覧', '', class: 'block p-3 text-white text-center' %>
+    </li>
+    <li>
+      <%= link_to '新規登録', '', class: 'block p-3 text-white text-center' %>
+    </li>
+    <li>
+      <%= link_to 'ログイン', '', class: 'block p-3 text-white text-center' %>
+    </li>
+  </ul>
+</header>


### PR DESCRIPTION
close #37 

# 概要
ログイン前のヘッダーを作成する。

## パス
`app/views/shared/_before_login_header.html.erb`

## 実装
- `_before_login_header.html.erb`にヘッダーを作成する

## 確認
- [x] 左側にロゴ、右側にナビゲーションが表示されているか
- [x] ナビゲーションの内容は正しいか
  - [x] コード一覧
  - [x] 新規登録
  - [x] ログイン
- [x] CSSの崩れはないか
- [x] レスポンシブ対応できているか

## ゴール
テキスト漏れや表示崩れがなくヘッダーが表示されている