### PR TITLE
usersテーブルとのリレーションが無かったため、postsテーブルを新しく作成

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,2 +1,3 @@
 class Post < ApplicationRecord
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  has_many :posts, dependent: :destroy
+
   validates :name, presence: true, length: { maximum: 100 }
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/db/migrate/20240722081815_create_posts.rb
+++ b/db/migrate/20240722081815_create_posts.rb
@@ -1,6 +1,7 @@
 class CreatePosts < ActiveRecord::Migration[7.1]
   def change
     create_table :posts do |t|
+      t.references :user, null: false, foreign_key: true
       t.string :title, null: false, default: ''
       t.text :description, default: ''
       t.boolean :public

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,17 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_22_074452) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_22_081815) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "posts", force: :cascade do |t|
+    t.bigint "user_id", null: false
     t.string "title", default: "", null: false
     t.text "description", default: ""
     t.boolean "public"
     t.string "image"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -36,4 +38,5 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_22_074452) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "posts", "users"
 end


### PR DESCRIPTION
# 概要
usersテーブルとのリレーション設定が追加されているpostsテーブルを作成

## パス
`app/models/post.rb`

## attribute
- user_id(integer)
- title(string)
- description(text)
- public(boolean)
- image(string)

## 制約
- title：nullを許容しない

## 確認
- [x] Postsテーブルのカラムと型は正しいか
  - [ ] user_id(integer)
  - [x] title(string)
  - [x] description(text)
  - [x] public(boolean)
  - [x] image(string)
- [x] タイトルがnullを許容しない設定になっているか
- [x] モデルの`post.rb`に`belongs_to :user`が記述されている
- [x] モデルの`user.rb`に`has_many :posts, dependent: :destroy`が記述されている

## やらなかったこと
- Postモデルのバリデーション設定

## ゴール
db/schema.rbに上記のカラムがあるPostsテーブルが生成されている