### PR TITLE
gem rails-i18n, devise-i18nの導入し、各ページを日本語対応化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,12 @@ gem "bootsnap", require: false
 # 認証
 gem "devise"
 
+# deviseの日本語化
+gem "devise-i18n"
+
+# 多言語対応
+gem "rails-i18n"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,8 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-i18n (1.12.1)
+      devise (>= 4.9.0)
     drb (2.2.1)
     erubi (1.13.0)
     globalid (1.2.1)
@@ -197,6 +199,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails-i18n (7.0.9)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.1.3.4)
       actionpack (= 7.1.3.4)
       activesupport (= 7.1.3.4)
@@ -272,11 +277,13 @@ DEPENDENCIES
   cssbundling-rails
   debug
   devise
+  devise-i18n
   jbuilder
   jsbundling-rails
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.4)
+  rails-i18n
   selenium-webdriver
   sprockets-rails
   stimulus-rails

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,6 +1,6 @@
 <section class="py-10 md:py-20">
   <div class="mx-auto max-w-3xl px-5">
-    <h2 class="text-3xl font-bold text-center md:text-4xl">新規登録</h2>
+    <h2 class="text-3xl font-bold text-center md:text-4xl"><%= t('.title') %></h2>
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: 'mt-10' }) do |f| %>
       <%= render "devise/shared/error_messages", resource: resource %>
 
@@ -17,9 +17,9 @@
 
         <div>
           <%= f.label :password, class: 'inline-block text-base md:text-lg' %>
-          <% if @minimum_password_length %>
-            <em>(<%= @minimum_password_length %> characters minimum)</em>
-          <% end %>
+            <% if @minimum_password_length %>
+              <em><%= t("devise.shared.minimum_password_length", count: @minimum_password_length) %></em>
+            <% end %>
           <%= f.password_field :password, autocomplete: "new-password", class: 'block mt-2 rounded w-full p-2 bg-white text-base md:px-4 md:py-3' %>
         </div>
 
@@ -30,7 +30,7 @@
       </div>
 
       <div class="mt-10 text-center">
-        <%= f.submit "新規登録", class: 'inline-block rounded max-w-[160px] w-full p-3 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70' %>
+        <%= f.submit t('.sign_up'), class: 'inline-block rounded max-w-[160px] w-full p-3 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70' %>
       </div>
     <% end %>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,6 +1,6 @@
 <section class="py-10 md:py-20">
   <div class="mx-auto max-w-3xl px-5">
-    <h2 class="text-3xl font-bold text-center md:text-4xl">ログイン</h2>
+    <h2 class="text-3xl font-bold text-center md:text-4xl"><%= t('.title') %></h2>
     <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: 'mt-10' }) do |f| %>
       <div class="grid grid-cols-1 gap-5">
         <div>
@@ -22,7 +22,7 @@
       </div>
 
       <div class="mt-10 text-center">
-        <%= f.submit "ログイン", class: 'inline-block rounded max-w-[160px] w-full p-3 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70' %>
+        <%= f.submit t('.sign_in'), class: 'inline-block rounded max-w-[160px] w-full p-3 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70' %>
       </div>
     <% end %>
 

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,21 +1,21 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "ログインページへ", new_session_path(resource_name), class: 'text-lg hover:underline' %>
+  <%= link_to t('devise.shared.links.sign_in'), new_session_path(resource_name), class: 'text-lg hover:underline' %>
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "新規登録", new_registration_path(resource_name), class: 'text-lg hover:underline' %>
+  <%= link_to t('devise.shared.links.sign_up'), new_registration_path(resource_name), class: 'text-lg hover:underline' %>
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "パスワードをお忘れの方はこちら", new_password_path(resource_name), class: 'text-lg hover:underline' %>
+  <%= link_to t('devise.shared.links.forgot_your_password'), new_password_path(resource_name), class: 'text-lg hover:underline' %>
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %>
+  <%= link_to t('devise.shared.links.didn_t_receive_confirmation_instructions'), new_confirmation_path(resource_name) %>
 <% end %>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %>
+  <%= link_to t('devise.shared.links.didn_t_receive_unlock_instructions'), new_unlock_path(resource_name) %>
 <% end %>
 
 <%- if devise_mapping.omniauthable? %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -5,7 +5,7 @@
       <h3 class="text-lg font-bold line-clamp-2"><%= post.title %></h3>
       <div class="flex justify-between items-center gap-5 mt-4">
         <span class="inline-block flex-shrink-0 rounded-full px-2 py-1 bg-sub-color text-white text-sm">カテゴリー</span>
-        <time class="text-base font-normal" datetime=""><%= post.created_at %></time>
+        <time class="text-base font-normal" datetime="<%= l post.created_at, format: :datetime %>"><%= l post.created_at %></time>
       </div>
       <p class="mt-4 text-base line-clamp-2"><%= post.description %></p>
     </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,12 +1,12 @@
 <section class="py-10 md:py-20">
   <div class="mx-auto max-w-xl px-5 md:max-w-3xl lg:max-w-5xl">
-    <h2 class="text-3xl font-bold text-center md:text-4xl">コード一覧</h2>
+    <h2 class="text-3xl font-bold text-center md:text-4xl"><%= t('.title') %></h2>
     <% if @posts.present? %>
       <div class="grid grid-cols-1 gap-5 mt-10 md:grid-cols-2 md:gap-10 lg:grid-cols-3">
         <%= render @posts %>
       </div>
     <% else %>
-      <p class="mt-10 text-lg text-center md:mt-20">現在、投稿がありません。</p>
+      <p class="mt-10 text-lg text-center md:mt-20"><%= t('.no_post') %></p>
     <% end %>
   </div>
 </section>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,6 +1,6 @@
 <section class="py-10 md:py-20">
   <div class="mx-auto max-w-3xl px-5">
-    <h2 class="text-3xl font-bold text-center md:text-4xl">新規投稿</h2>
+    <h2 class="text-3xl font-bold text-center md:text-4xl"><%= t('.title') %></h2>
     <%= form_with model: @post, class: 'grid grid-cols-1 gap-5 mt-10' do |f| %>
       <div>
         <%= f.label :title, class: 'inline-block text-base md:text-lg' %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,17 +1,17 @@
 <header class="flex justify-between items-center sticky top-0 left-0 z-50 h-14 pl-5 bg-sub-color shadow-md md:h-16 md:px-5">
   <h1 class="h-full">
-    <%= link_to 'CodeSheet', root_path, class: 'flex items-center h-full text-white text-2xl font-bold md:text-4xl' %>
+    <%= link_to t('header.title'), root_path, class: 'flex items-center h-full text-white text-2xl font-bold md:text-4xl' %>
   </h1>
   <nav class="hidden h-full md:block">
     <ul class="flex gap-5 h-full">
       <li class="h-full">
-        <%= link_to 'コード一覧', posts_path, class: 'flex items-center h-full text-white hover:underline' %>
+        <%= link_to t('header.post_index'), posts_path, class: 'flex items-center h-full text-white hover:underline' %>
       </li>
       <li class="h-full">
-        <%= link_to '新規登録', new_user_registration_path, class: 'flex items-center h-full text-white hover:underline' %>
+        <%= link_to t('header.create_user'), new_user_registration_path, class: 'flex items-center h-full text-white hover:underline' %>
       </li>
       <li class="h-full">
-        <%= link_to 'ログイン', new_user_session_path, class: 'flex items-center h-full text-white hover:underline' %>
+        <%= link_to t('header.login'), new_user_session_path, class: 'flex items-center h-full text-white hover:underline' %>
       </li>
     </ul>
   </nav>
@@ -22,13 +22,13 @@
   </button>
   <ul class="flex flex-col gap-1 fixed top-14 right-0 translate-x-40 z-50 w-40 py-3 bg-sub-color duration-300 js-header-menu">
     <li>
-      <%= link_to 'コード一覧', posts_path, class: 'block p-3 text-white text-center' %>
+      <%= link_to t('header.post_index'), posts_path, class: 'block p-3 text-white text-center' %>
     </li>
     <li>
-      <%= link_to '新規登録', new_user_registration_path, class: 'block p-3 text-white text-center' %>
+      <%= link_to t('header.create_user'), new_user_registration_path, class: 'block p-3 text-white text-center' %>
     </li>
     <li>
-      <%= link_to 'ログイン', new_user_session_path, class: 'block p-3 text-white text-center' %>
+      <%= link_to t('header.login'), new_user_session_path, class: 'block p-3 text-white text-center' %>
     </li>
   </ul>
 </header>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,13 +1,13 @@
 <footer class="py-10 bg-footer-color">
   <ul class="flex flex-col md:flex-row md:justify-center md:gap-5">
     <li>
-      <%= link_to '利用規約', '#', class: 'block p-3 text-white text-center md:inline-block hover:underline' %>
+      <%= link_to t('footer.terms_of_service'), '#', class: 'block p-3 text-white text-center md:inline-block hover:underline' %>
     </li>
     <li>
-      <%= link_to 'プライバシーポリシー', '#', class: 'block p-3 text-white text-center md:inline-block hover:underline' %>
+      <%= link_to t('footer.privacy_policy'), '#', class: 'block p-3 text-white text-center md:inline-block hover:underline' %>
     </li>
     <li>
-      <%= link_to 'お問い合わせ', '#', class: 'block p-3 text-white text-center md:inline-block hover:underline' %>
+      <%= link_to t('footer.contact'), '#', class: 'block p-3 text-white text-center md:inline-block hover:underline' %>
     </li>
   </ul>
   <p class="mt-5 text-white font-medium text-center">© 2024 CodeSheet All Rights Reserved.</p>

--- a/app/views/shared/_login_header.html.erb
+++ b/app/views/shared/_login_header.html.erb
@@ -5,10 +5,10 @@
   <nav class="hidden h-full md:block">
     <ul class="flex gap-5 h-full">
       <li class="h-full">
-        <%= link_to 'コード一覧', posts_path, class: 'flex items-center h-full text-white hover:underline' %>
+        <%= link_to t('header.post_index'), posts_path, class: 'flex items-center h-full text-white hover:underline' %>
       </li>
       <li class="h-full">
-        <%= link_to 'コード登録', new_post_path, class: 'flex items-center h-full text-white hover:underline' %>
+        <%= link_to t('header.post_new'), new_post_path, class: 'flex items-center h-full text-white hover:underline' %>
       </li>
       <li class="h-full">
         <button type="button" class="flex items-center h-full text-white hover:underline js-user-btn">
@@ -19,16 +19,16 @@
   </nav>
   <ul class="flex flex-col gap-1 fixed top-14 right-0 translate-x-52 z-50 w-52 py-3 bg-sub-color duration-300 js-user-menu">
     <li>
-      <%= link_to 'マイページ', '', class: 'block p-3 text-white text-center hover:underline' %>
+      <%= link_to t('header.my_page'), '', class: 'block p-3 text-white text-center hover:underline' %>
     </li>
     <li>
-      <%= link_to 'マイコード一覧', '', class: 'block p-3 text-white text-center hover:underline' %>
+      <%= link_to t('header.my_post_index'), '', class: 'block p-3 text-white text-center hover:underline' %>
     </li>
     <li>
-      <%= link_to 'ブックマーク一覧', '', class: 'block p-3 text-white text-center hover:underline' %>
+      <%= link_to  t('header.bookmark_index'), '', class: 'block p-3 text-white text-center hover:underline' %>
     </li>
     <li>
-      <%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete }, class: 'block p-3 text-white text-center hover:underline' %>
+      <%= link_to  t('header.logout'), destroy_user_session_path, data: { turbo_method: :delete }, class: 'block p-3 text-white text-center hover:underline' %>
     </li>
   </ul>
 
@@ -37,22 +37,22 @@
   </button>
   <ul class="flex flex-col gap-1 fixed top-14 right-0 translate-x-40 z-50 w-40 py-3 bg-sub-color duration-300 js-header-menu">
     <li>
-      <%= link_to 'コード一覧', posts_path, class: 'block p-3 text-white text-center' %>
+      <%= link_to t('header.post_index'), posts_path, class: 'block p-3 text-white text-center' %>
     </li>
     <li>
-      <%= link_to 'コード登録', new_post_path, class: 'block p-3 text-white text-center' %>
+      <%= link_to t('header.post_new'), new_post_path, class: 'block p-3 text-white text-center' %>
     </li>
     <li>
-      <%= link_to 'マイページ', '', class: 'block p-3 text-white text-center' %>
+      <%= link_to t('header.my_page'), '', class: 'block p-3 text-white text-center' %>
     </li>
     <li>
-      <%= link_to 'マイコード一覧', '', class: 'block p-3 text-white text-center' %>
+      <%= link_to t('header.my_post_index'), '', class: 'block p-3 text-white text-center' %>
     </li>
     <li>
-      <%= link_to 'ブックマーク一覧', '', class: 'block p-3 text-white text-center' %>
+      <%= link_to  t('header.bookmark_index'), '', class: 'block p-3 text-white text-center' %>
     </li>
     <li>
-      <%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete }, class: 'block p-3 text-white text-center' %>
+      <%= link_to  t('header.logout'), destroy_user_session_path, data: { turbo_method: :delete }, class: 'block p-3 text-white text-center' %>
     </li>
   </ul>
 </header>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,0 +1,10 @@
+ja:
+  activerecord:
+    models:
+      user: ユーザー
+    attributes:
+      user:
+        name: 名前
+      post:
+        title: タイトル
+        description: コード説明

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,145 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: メールアドレス
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード確認
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザー
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: ログインもしくはアカウント登録してください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。
+        message_unconfirmed: メールアドレスが（%{email}）変更されたため、メールを送信しています。
+        subject: メール変更完了
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        title: 新規登録
+        sign_up: 新規登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        title: ログイン
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードをお忘れの方はこちら
+        sign_in: ログインページへ
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: 新規登録
+      minimum_password_length: "（%{count}文字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -1,0 +1,34 @@
+ja:
+  helper:
+    submit:
+      create: 登録
+      update: 更新
+      save: 保存
+  header:
+    title: CodeSheet
+    login: ログイン
+    logout: ログアウト
+    create_user: 新規登録
+    post_index: コード一覧
+    post_new: コード登録
+    my_page: マイページ
+    my_post_index: マイコード一覧
+    bookmark_index: ブックマーク一覧
+  footer:
+    terms_of_service: 利用規約
+    privacy_policy: プライバシーポリシー
+    contact: お問い合わせ
+  time:
+    formats:
+      default: "%Y/%m/%d"
+      datetime: "%Y-%m-%d"
+  users:
+    new:
+      title: 新規登録
+      to_login_page: ログインページへ
+  posts:
+    index:
+      title: コード一覧
+      no_post: 現在、投稿がありません
+    new:
+      title: コード登録


### PR DESCRIPTION
# 概要
フォームのラベルが英語になっているので、i18nを導入して日本語化対応をする

## パス
`config/locales/devise.ja.yml`
`config/locales/activerecord/ja.yml`
`config/locales/view/ja.yml`

## 実装
- gem `rails-i18n`, `devise-i18n-views`の導入
- `devise.ja.yml`ファイルにユーザー機能があるページの日本語対応
  - 新規登録
  - ログイン
- `activerecord/ja.yml`, `view/ja.yml`ファイルに新規投稿ページの日本語化対応
- 投稿一覧の日付フォーマットを日本に対応

## 確認
- [x] フォーム機能があるページが日本語対応になっている
  - [x] 新規登録
  - [x] ログイン
  - [x] 新規投稿
- [x] 投稿一覧の日付フォーマットが日本になっている

## 上記以外にやったこと
- ヘッダーとフッターの日本語対応
- 各ページのタイトルの日本語対応

## ゴール
フォームのラベル・投稿一覧の日付フォーマットが日本対応になっている