### PR TITLE
投稿詳細ページの作成

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -16,6 +16,10 @@ class PostsController < ApplicationController
     end
   end
 
+  def show
+    @post = Post.find(params[:id])
+  end
+
   private
 
   def post_params

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,5 +1,5 @@
 <article>
-  <%= link_to '#', class: 'flex flex-col h-full bg-white shadow-md duration-300 hover:shadow-xl hover:-translate-y-1.5' do %>
+  <%= link_to post_path(post), class: 'flex flex-col h-full bg-white shadow-md duration-300 hover:shadow-xl hover:-translate-y-1.5' do %>
     <%= image_tag 'no_image.jpg', class: 'grow-0 w-full h-full object-cover aspect-[300/200]' %>
     <div class="p-5">
       <h3 class="text-lg font-bold line-clamp-2"><%= post.title %></h3>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,0 +1,10 @@
+<section class="py-10 md:py-20">
+  <div class="mx-auto max-w-xl px-5 md:max-w-3xl lg:max-w-5xl">
+    <h2 class="text-2xl font-bold md:text-3xl"><%= @post.title %></h2>
+    <div class="flex items-center gap-5 mt-5 md:gap-10 md:mt-10">
+      <span class="inline-block flex-shrink-0 rounded-full px-2 py-1 bg-sub-color text-white text-sm">カテゴリー</span>
+      <time class="text-base font-normal" datetime="<%= l @post.created_at, format: :datetime %>"><%= l @post.created_at %></time>
+    </div>
+    <p class="mt-5 text-base md:mt-10 md:text-lg"><%= @post.description %></p>
+  </div>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root "static_pages#top"
-  resources :posts, only: %i[index new create]
+  resources :posts, only: %i[index new create show]
 
   get "up" => "rails/health#show", as: :rails_health_check
 end


### PR DESCRIPTION
close #46 

# 概要
投稿の詳細機能を作成するため、Postsコントローラにshowアクションを追加し詳細ページを作成する

## パス
`app/views/posts/show.html.erb`

## 実装
- Postsコントローラーにshowアクションを作成
- 詳細ページにタイトルと概要を表示させる
- 一覧の投稿から詳細ページへのリンクを追加

## 確認
- [x] 詳細ページに投稿のタイトルと概要が表示されているか
- [x] 一覧の投稿から詳細ページに遷移できるか
- [x] CSSの崩れはないか
- [x] レスポンシブ対応が出来ているか

- 以下の機能は後で実装するので、タイトルと概要のみ確認する
  - コード機能
  - 画像
  - 公開・非公開

## ゴール
投稿一覧の投稿から詳細ページに遷移でき、投稿の詳細が表示されている