### PR TITLE
投稿に画像投稿機能実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,9 @@ gem "devise-i18n"
 # 多言語対応
 gem "rails-i18n"
 
+# 画像のアップロード
+gem 'carrierwave', '~> 3.0'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,13 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    carrierwave (3.0.7)
+      activemodel (>= 6.0.0)
+      activesupport (>= 6.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      marcel (~> 1.0.0)
+      ssrf_filter (~> 1.0)
     concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -112,10 +119,19 @@ GEM
       devise (>= 4.9.0)
     drb (2.2.1)
     erubi (1.13.0)
+    ffi (1.17.0-aarch64-linux-gnu)
+    ffi (1.17.0-arm-linux-gnu)
+    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86-linux-gnu)
+    ffi (1.17.0-x86_64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.2)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     io-console (0.7.2)
     irb (1.14.0)
       rdoc (>= 4.0.0)
@@ -136,6 +152,7 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.24.1)
     msgpack (1.7.2)
@@ -221,6 +238,9 @@ GEM
       railties (>= 5.2)
     rexml (3.3.2)
       strscan
+    ruby-vips (2.2.2)
+      ffi (~> 1.12)
+      logger
     rubyzip (2.3.2)
     selenium-webdriver (4.22.0)
       base64 (~> 0.2)
@@ -235,6 +255,7 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
+    ssrf_filter (1.1.2)
     stimulus-rails (1.3.3)
       railties (>= 6.0.0)
     stringio (3.1.1)
@@ -274,6 +295,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   capybara
+  carrierwave (~> 3.0)
   cssbundling-rails
   debug
   devise

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -23,6 +23,6 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:title, :description)
+    params.require(:post).permit(:title, :description, :image, :image_cache)
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,3 +1,7 @@
 class Post < ApplicationRecord
   belongs_to :user
+
+  validates :title, presence: true, length: { maximum: 100 }
+
+  mount_uploader :image, ImageUploader
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,0 +1,45 @@
+class ImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # ファイルがアップロードされていない場合に表示するデフォルトの画像を設定
+  def default_url(*args)
+    # For Rails 3.1+ asset pipeline compatibility:
+    # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+    "no_image.jpg"
+  end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # 許可するファイルの拡張子のリストを設定
+  def extension_allowlist
+    %w(jpg jpeg gif png)
+  end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg"
+  # end
+end

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,13 +1,9 @@
-<article>
-  <%= link_to post_path(post), class: 'flex flex-col h-full bg-white shadow-md duration-300 hover:shadow-xl hover:-translate-y-1.5' do %>
-    <%= image_tag 'no_image.jpg', class: 'grow-0 w-full h-full object-cover aspect-[300/200]' %>
-    <div class="p-5">
-      <h3 class="text-lg font-bold line-clamp-2"><%= post.title %></h3>
-      <div class="flex justify-between items-center gap-5 mt-4">
-        <span class="inline-block flex-shrink-0 rounded-full px-2 py-1 bg-sub-color text-white text-sm">カテゴリー</span>
-        <time class="text-base font-normal" datetime="<%= l post.created_at, format: :datetime %>"><%= l post.created_at %></time>
-      </div>
-      <p class="mt-4 text-base line-clamp-2"><%= post.description %></p>
-    </div>
-  <% end %>
-</article>
+<%= link_to post_path(post), class: 'grid grid-rows-subgrid row-span-4 gap-5 pb-5 bg-white shadow-md duration-300 hover:shadow-xl hover:-translate-y-1.5' do %>
+  <%= image_tag post.image_url, class: 'w-full object-cover aspect-[300/200]' %>
+  <h3 class="px-5 text-lg font-bold line-clamp-2"><%= post.title %></h3>
+  <div class="flex justify-between items-center gap-5 px-5">
+    <span class="inline-block flex-shrink-0 rounded-full px-2 py-1 bg-sub-color text-white text-sm">カテゴリー</span>
+    <time class="text-base font-normal" datetime="<%= l post.created_at, format: :datetime %>"><%= l post.created_at %></time>
+  </div>
+  <p class="px-5 text-base line-clamp-2"><%= post.description %></p>
+<% end %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -12,6 +12,12 @@
         <%= f.text_area :description, autofocus: true, class: 'block mt-2 rounded w-full p-2 bg-white text-base md:px-4 md:py-3' %>
       </div>
 
+      <div>
+        <%= f.label :image, class: 'inline-block text-base md:text-lg' %>
+        <%= f.file_field :image, class: 'block mt-2 w-full text-base', accept: 'image/*' %>
+        <%= f.hidden_field :image_cache %>
+      </div>
+
       <div class="mt-10 text-center">
         <%= f.submit "投稿する", class: 'inline-block rounded max-w-[160px] w-full p-3 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70' %>
       </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -6,5 +6,8 @@
       <time class="text-base font-normal" datetime="<%= l @post.created_at, format: :datetime %>"><%= l @post.created_at %></time>
     </div>
     <p class="mt-5 text-base md:mt-10 md:text-lg"><%= @post.description %></p>
+    <div class="mt-5 mx-auto max-w-xl md:mt-10">
+      <%= image_tag @post.image_url, class: 'w-full max-h-[800px] object-contain' %>
+    </div>
   </div>
 </section>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -8,3 +8,4 @@ ja:
       post:
         title: タイトル
         description: コード説明
+        image: サムネイル


### PR DESCRIPTION
close #47 

# 概要
gem carrierwaveを導入し、投稿に画像投稿機能を追加する

## 実装
- gem carrierwaveをインストールし、postモデルにimage(string)カラムを追加
- アップロードできるファイルをjpg, jpeg, png, gifのみに設定する
- 投稿一覧と詳細にimage_tagを使用して画像を表示させる

## 確認
- [x] 画像の投稿が適切にできるか
- [x] 拡張子がjpg,jpeg,png,gifのみアップロード出来るようになっているか
- [x] 投稿一覧と詳細に画像が表示されているか
- [x] 画像が登録されていない時、no image画像が表示されているか

## ゴール
投稿の新規投稿ページから画像が登録できるようになる