### PR TITLE
投稿編集機能実装

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -20,6 +20,19 @@ class PostsController < ApplicationController
     @post = Post.find(params[:id])
   end
 
+  def edit
+    @post = current_user.posts.find(params[:id])
+  end
+
+  def update
+    @post = current_user.posts.find(params[:id])
+    if @post.update(post_params)
+      redirect_to post_path(@post)
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def post_params

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,8 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  def own?(object)
+    id == object&.user_id
+  end
 end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,0 +1,21 @@
+<%= form_with model: @post, class: 'grid grid-cols-1 gap-5 mt-10' do |f| %>
+  <div>
+    <%= f.label :title, class: 'inline-block text-base md:text-lg' %>
+    <%= f.text_field :title, autofocus: true, class: 'block mt-2 rounded w-full p-2 bg-white text-base md:px-4 md:py-3' %>
+  </div>
+
+  <div>
+    <%= f.label :description, class: 'inline-block text-base md:text-lg' %>
+    <%= f.text_area :description, autofocus: true, class: 'block mt-2 rounded w-full p-2 bg-white text-base md:px-4 md:py-3' %>
+  </div>
+
+  <div>
+    <%= f.label :image, class: 'inline-block text-base md:text-lg' %>
+    <%= f.file_field :image, class: 'block mt-2 w-full text-base', accept: 'image/*' %>
+    <%= f.hidden_field :image_cache %>
+  </div>
+
+  <div class="mt-10 text-center">
+    <%= f.submit nil, class: 'inline-block rounded max-w-[160px] w-full p-3 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70' %>
+  </div>
+<% end %>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,0 +1,6 @@
+<section class="py-10 md:py-20">
+  <div class="mx-auto max-w-3xl px-5">
+    <h2 class="text-3xl font-bold text-center md:text-4xl"><%= t('.title') %></h2>
+    <%= render 'form', post: @post %>
+  </div>
+</section>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,26 +1,6 @@
 <section class="py-10 md:py-20">
   <div class="mx-auto max-w-3xl px-5">
     <h2 class="text-3xl font-bold text-center md:text-4xl"><%= t('.title') %></h2>
-    <%= form_with model: @post, class: 'grid grid-cols-1 gap-5 mt-10' do |f| %>
-      <div>
-        <%= f.label :title, class: 'inline-block text-base md:text-lg' %>
-        <%= f.text_field :title, autofocus: true, class: 'block mt-2 rounded w-full p-2 bg-white text-base md:px-4 md:py-3' %>
-      </div>
-
-      <div>
-        <%= f.label :description, class: 'inline-block text-base md:text-lg' %>
-        <%= f.text_area :description, autofocus: true, class: 'block mt-2 rounded w-full p-2 bg-white text-base md:px-4 md:py-3' %>
-      </div>
-
-      <div>
-        <%= f.label :image, class: 'inline-block text-base md:text-lg' %>
-        <%= f.file_field :image, class: 'block mt-2 w-full text-base', accept: 'image/*' %>
-        <%= f.hidden_field :image_cache %>
-      </div>
-
-      <div class="mt-10 text-center">
-        <%= f.submit "投稿する", class: 'inline-block rounded max-w-[160px] w-full p-3 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70' %>
-      </div>
-    <% end %>
+    <%= render 'form', post: @post %>
   </div>
 </section>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -9,5 +9,12 @@
     <div class="mt-5 mx-auto max-w-xl md:mt-10">
       <%= image_tag @post.image_url, class: 'w-full max-h-[800px] object-contain' %>
     </div>
+
+    <% if current_user.own?(@post) %>
+      <div class="flex justify-center gap-5 mt-10">
+        <%= link_to t('helper.submit.edit'), edit_post_path(@post), class: 'inline-block rounded max-w-[160px] w-full p-3 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70' %>
+        <%= link_to t('helper.submit.destroy'), '#', class: 'inline-block rounded max-w-[160px] w-full p-3 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70' %>
+      </div>
+    <% end %>
   </div>
 </section>

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -1,9 +1,11 @@
 ja:
   helper:
     submit:
-      create: 登録
-      update: 更新
-      save: 保存
+      create: 登録する
+      update: 更新する
+      save: 保存する
+      edit: 編集する
+      destroy: 削除する
   header:
     title: CodeSheet
     login: ログイン
@@ -32,3 +34,5 @@ ja:
       no_post: 現在、投稿がありません
     new:
       title: コード登録
+    edit:
+      title: コード編集

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root "static_pages#top"
-  resources :posts, only: %i[index new create show]
+  resources :posts, only: %i[index new create show edit update]
 
   get "up" => "rails/health#show", as: :rails_health_check
 end


### PR DESCRIPTION
close #48 

# 概要
投稿の編集をできるようにするため、Postsコントローラーのedit・updateアクションを作成及び編集ページを作成

## パス
`app/controllers/posts_controller.rb`
`app/views/posts/edit.html.erb`

## 実装
- Postsコントローラーにedit・updateアクション追加
- form_withを使用してフォームを実装する。ラベルは以下
  - title(タイトル)
  - description(概要)
  - image(画像)
- 自分の投稿詳細にのみ編集ボタンが表示されるように設定
- 投稿詳細の編集ボタンから編集ページに遷移するように設定
- 正しく入力できた時、コード詳細ページに遷移するように設定

## 確認
- [ ] タイトルが未入力の時、エラーが表示されるか
- [x] 画像の変更が正しくできるか
- [x] 自分の投稿詳細にのみ編集ボタンが表示されているか
- [x] 正しく入力できた時、DBが更新されているか
- [x] 正しく入力された時、投稿詳細に遷移するか

## やらなかったこと
- エラー表示とフラッシュメッセージ表示は後ほど実装予定

## ゴール
ユーザーの名前・メールアドレス・アバターが変更できるようになる