### PR TITLE
投稿削除機能実装

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -33,6 +33,12 @@ class PostsController < ApplicationController
     end
   end
 
+  def destroy
+    @post = current_user.posts.find(params[:id])
+    @post.destroy!
+    redirect_to posts_path, status: :see_other
+  end
+
   private
 
   def post_params

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -13,7 +13,7 @@
     <% if current_user.own?(@post) %>
       <div class="flex justify-center gap-5 mt-10">
         <%= link_to t('helper.submit.edit'), edit_post_path(@post), class: 'inline-block rounded max-w-[160px] w-full p-3 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70' %>
-        <%= link_to t('helper.submit.destroy'), '#', class: 'inline-block rounded max-w-[160px] w-full p-3 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70' %>
+        <%= link_to t('helper.submit.destroy'), post_path(@post), class: 'inline-block rounded max-w-[160px] w-full p-3 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70', data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } %>
       </div>
     <% end %>
   </div>

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -1,4 +1,6 @@
 ja:
+  defaults:
+    delete_confirm: 削除しますか？
   helper:
     submit:
       create: 登録する

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root "static_pages#top"
-  resources :posts, only: %i[index new create show edit update]
+  resources :posts, only: %i[index new create show edit update destroy]
 
   get "up" => "rails/health#show", as: :rails_health_check
 end


### PR DESCRIPTION
close #49 

# 概要
ユーザーが自分の投稿を削除出来るようにするため、Postsコントローラーにdestoryアクションを追加する

## パス
`app/controllers/posts_controller.rb`
`app/views/posts/show.html.erb`

## 実装
- Postsコントローラーにdestroyアクションを追加
- 削除の確認をするため、ダイアログに「投稿を削除しますか？」と表示させるように設定
- 削除が成功したら投稿一覧ページに遷移するように設定

## 確認
- [x] 自分の投稿詳細にのみ削除ボタンが表示される
- [x] 削除ボタンを押した時に「投稿を削除しますか？」というダイアログが表示される
- [x] 投稿削除機能が正常に動作するか

## ゴール
ユーザーが自分の投稿を削除出来るようになる