### PR TITLE
マイページ作成

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,5 +6,7 @@ class ApplicationController < ActionController::Base
   def configure_permitted_parameters
     # サインアップ時にnameのストロングパラメータを追加
     devise_parameter_sanitizer.permit(:sign_up, keys: %i[name])
+    # アカウント編集時にnameのストロングパラメータを追加
+    devise_parameter_sanitizer.permit(:account_update, keys: %i[name])
   end
 end

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  # def after_confirmation_path_for(resource_name, resource)
+  #   super(resource_name, resource)
+  # end
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # You should configure your model like this:
+  # devise :omniauthable, omniauth_providers: [:twitter]
+
+  # You should also create an action method in this controller like this:
+  # def twitter
+  # end
+
+  # More info at:
+  # https://github.com/heartcombo/devise#omniauth
+
+  # GET|POST /resource/auth/twitter
+  # def passthru
+  #   super
+  # end
+
+  # GET|POST /users/auth/twitter/callback
+  # def failure
+  #   super
+  # end
+
+  # protected
+
+  # The path used when OmniAuth fails
+  # def after_omniauth_failure_path_for(scope)
+  #   super(scope)
+  # end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Users::PasswordsController < Devise::PasswordsController
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  # def update
+  #   super
+  # end
+
+  # protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  # def create
+  #   super
+  # end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Users::SessionsController < Devise::SessionsController
+  # before_action :configure_sign_in_params, only: [:create]
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+end

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::UnlocksController < Devise::UnlocksController
+  # GET /resource/unlock/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/unlock
+  # def create
+  #   super
+  # end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after sending unlock password instructions
+  # def after_sending_unlock_instructions_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after unlocking the resource
+  # def after_unlock_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,5 @@
+class UsersController < ApplicationController
+  def show
+    @user = User.find(current_user.id)
+  end
+end

--- a/app/views/shared/_login_header.html.erb
+++ b/app/views/shared/_login_header.html.erb
@@ -19,7 +19,7 @@
   </nav>
   <ul class="flex flex-col gap-1 fixed top-14 right-0 translate-x-52 z-50 w-52 py-3 bg-sub-color duration-300 js-user-menu">
     <li>
-      <%= link_to t('header.my_page'), '', class: 'block p-3 text-white text-center hover:underline' %>
+      <%= link_to t('header.my_page'), user_path(current_user), class: 'block p-3 text-white text-center hover:underline' %>
     </li>
     <li>
       <%= link_to t('header.my_post_index'), '', class: 'block p-3 text-white text-center hover:underline' %>
@@ -43,7 +43,7 @@
       <%= link_to t('header.post_new'), new_post_path, class: 'block p-3 text-white text-center' %>
     </li>
     <li>
-      <%= link_to t('header.my_page'), '', class: 'block p-3 text-white text-center' %>
+      <%= link_to t('header.my_page'), user_path(current_user), class: 'block p-3 text-white text-center' %>
     </li>
     <li>
       <%= link_to t('header.my_post_index'), '', class: 'block p-3 text-white text-center' %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,25 @@
+<section class="py-10 md:py-20">
+  <div class="mx-auto max-w-xl px-5">
+    <h2 class="text-3xl font-bold text-center md:text-4xl"><%= t('.title') %></h2>
+    <dl class="grid grid-cols-1 gap-5 mt-10 md:gap-10">
+      <div class="grid grid-cols-1 gap-2 md:grid-cols-[160px_1fr] md:gap-5">
+        <dt class="text-lg font-bold md:text-xl"><%= t('.user_name') %></dt>
+        <dd class="text-base font-normal md:text-lg"><%= @user.name %></dd>
+      </div>
+      <div class="grid grid-cols-1 gap-2 md:grid-cols-[160px_1fr] md:gap-5">
+        <dt class="text-lg font-bold"><%= t('.email') %></dt>
+        <dd class="text-base font-normal break-all"><%= @user.email %></dd>
+      </div>
+      <div class="grid grid-cols-1 gap-2 md:grid-cols-[160px_1fr] md:items-center md:gap-5">
+        <dt class="text-lg font-bold"><%= t('.avatar') %></dt>
+        <dd class="text-base font-normal">
+          <%= image_tag 'user_icon.svg', size: '80x80', class: 'w-20 h-20 object-cover rounded-full', alt: 'アバターアイコン' %>
+        </dd>
+      </div>
+    </dl>
+    <div class="flex justify-center gap-5 mt-10">
+      <%= link_to '編集する', '', class: 'inline-block rounded max-w-[160px] w-full p-3 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70' %>
+      <%= link_to 'パスワード変更', '', class: 'inline-block rounded max-w-[160px] w-full p-3 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70', data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } %>
+    </div>
+  </div>
+</section>

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -30,6 +30,11 @@ ja:
     new:
       title: 新規登録
       to_login_page: ログインページへ
+    show:
+      title: マイページ
+      user_name: ユーザー名
+      email: メールアドレス
+      avatar: アバター
   posts:
     index:
       title: コード一覧

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,12 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: {
+    registrations: "users/registrations",
+    sessions: "users/sessions",
+    passwords: "users/passwords",
+    confirmations: "users/confirmations"
+  }
   root "static_pages#top"
+  resources :users, only: %i[show]
   resources :posts, only: %i[index new create show edit update destroy]
 
   get "up" => "rails/health#show", as: :rails_health_check


### PR DESCRIPTION
close #54 

# 概要
ユーザーの詳細な情報を見れるようにするため、マイページを作成する

## パス
`app/views/users/show.html.erb`

## 実装
- Usersコントローラーにshowアクションを追加
- マイページに名前・メールアドレス・アバター画像を表示させる
- ヘッダーのアイコンからマイページに遷移できるように設定
- アバター画像が登録されていない時、ダミー画像が表示されるように設定

## 確認
- [x] ヘッダーのアイコンからマイページに遷移できる
- [x] マイページに名前・メールアドレス・アバター画像が表示されている
- [ ] アバター画像が登録されていない時、ダミー画像が表示されているか
- [x] マイページの下部に編集ボタンとパスワード変更ボタンが表示されている（リンク先は空で良い）
- [x] CSSの崩れがない
- [x] レスポンシブ対応が出来ている

## やらなかったこと
- usersテーブルにavatarカラムを追加（後ほど実装）
- アバター画像が登録されていない時、ダミー画像が表示されているかの実装

## ゴール
ヘッダーのアイコンからユーザーの詳細ページが閲覧でき、ユーザー情報が見れる