### PR TITLE
マイページ編集機能追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,6 @@ class ApplicationController < ActionController::Base
     # サインアップ時にnameのストロングパラメータを追加
     devise_parameter_sanitizer.permit(:sign_up, keys: %i[name])
     # アカウント編集時にnameのストロングパラメータを追加
-    devise_parameter_sanitizer.permit(:account_update, keys: %i[name])
+    devise_parameter_sanitizer.permit(:account_update, keys: %i[name avatar avatar_cache])
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -38,7 +38,16 @@ class Users::RegistrationsController < Devise::RegistrationsController
   #   super
   # end
 
-  # protected
+  protected
+  # パスワード変更なしでユーザー情報を編集可能にする
+  def update_resource(resource, params)
+    resource.update_without_password(params)
+  end
+
+  # 更新後にマイページへリダイレクト
+  def after_update_path_for(resource)
+    user_path(current_user)
+  end
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_up_params

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  mount_uploader :avatar, AvatarUploader
+
   def own?(object)
     id == object&.user_id
   end

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -1,0 +1,45 @@
+class AvatarUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # ファイルがアップロードされていない場合に表示するデフォルトの画像を設定
+  def default_url(*args)
+    # For Rails 3.1+ asset pipeline compatibility:
+    # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+    "user_icon.svg"
+  end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # 許可するファイルの拡張子のリストを設定
+  def extension_allowlist
+    %w(jpg jpeg png svg)
+  end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg"
+  # end
+end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,43 +1,31 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<section class="py-10 md:py-20">
+  <div class="mx-auto max-w-3xl px-5">
+    <h2 class="text-3xl font-bold text-center md:text-4xl"><%= t('.title') %></h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: 'mt-10' }) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+      <div class="grid grid-cols-1 gap-5">
+        <div>
+          <%= f.label :name, class: 'inline-block text-base md:text-lg' %>
+          <%= f.text_field :name, autofocus: true, autocomplete: "name", class: 'block mt-2 rounded w-full p-2 bg-white text-base md:px-4 md:py-3' %>
+        </div>
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
+        <div>
+          <%= f.label :email, class: 'inline-block text-base md:text-lg' %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'block mt-2 rounded w-full p-2 bg-white text-base md:px-4 md:py-3' %>
+        </div>
 
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
+        <div>
+          <%= f.label :avatar, class: 'inline-block text-base md:text-lg' %>
+          <%= f.file_field :avatar, class: 'block mt-2 w-full text-base', accept: 'image/*' %>
+          <%= f.hidden_field :avatar_cache %>
+        </div>
+      </div>
+
+      <div class="mt-10 text-center">
+        <%= f.submit nil, class: 'inline-block rounded max-w-[160px] w-full p-3 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70' %>
+      </div>
     <% end %>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
-
-<%= link_to "Back", :back %>
+</section>

--- a/app/views/shared/_login_header.html.erb
+++ b/app/views/shared/_login_header.html.erb
@@ -12,7 +12,7 @@
       </li>
       <li class="h-full">
         <button type="button" class="flex items-center h-full text-white hover:underline js-user-btn">
-          <%= image_tag 'user_icon.svg', class: 'w-12 h-12 object-cover rounded-full', size: '48x48', alt: 'ユーザーアイコン' %>
+          <%= image_tag current_user.avatar_url, class: 'w-12 h-12 object-cover rounded-full', size: '48x48', alt: 'ユーザーアイコン' %>
         </button>
       </li>
     </ul>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -13,12 +13,12 @@
       <div class="grid grid-cols-1 gap-2 md:grid-cols-[160px_1fr] md:items-center md:gap-5">
         <dt class="text-lg font-bold"><%= t('.avatar') %></dt>
         <dd class="text-base font-normal">
-          <%= image_tag 'user_icon.svg', size: '80x80', class: 'w-20 h-20 object-cover rounded-full', alt: 'アバターアイコン' %>
+          <%= image_tag @user.avatar_url, size: '80x80', class: 'w-20 h-20 object-cover rounded-full', alt: 'アバターアイコン' %>
         </dd>
       </div>
     </dl>
     <div class="flex justify-center gap-5 mt-10">
-      <%= link_to '編集する', '', class: 'inline-block rounded max-w-[160px] w-full p-3 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70' %>
+      <%= link_to '編集する', edit_user_registration_path, class: 'inline-block rounded max-w-[160px] w-full p-3 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70' %>
       <%= link_to 'パスワード変更', '', class: 'inline-block rounded max-w-[160px] w-full p-3 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70', data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } %>
     </div>
   </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -5,6 +5,7 @@ ja:
     attributes:
       user:
         name: 名前
+        avatar: アバター
       post:
         title: タイトル
         description: コード説明

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -96,7 +96,7 @@ ja:
         cancel_my_account: アカウント削除
         currently_waiting_confirmation_for_email: "%{email} の確認待ち"
         leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
-        title: "%{resource}編集"
+        title: "マイページ"
         unhappy: 気に入りません
         update: 更新
         we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください

--- a/db/migrate/20240726103740_add_avatar_to_users.rb
+++ b/db/migrate/20240726103740_add_avatar_to_users.rb
@@ -1,0 +1,5 @@
+class AddAvatarToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :avatar, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_22_081815) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_26_103740) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -34,6 +34,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_22_081815) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "avatar"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
close #55

# 概要
ユーザーの情報を編集できるようにするため、Usersコントローラーのeditアクションを作成し及び編集ページを作成

## パス
`app/views/users/edit.html.erb`

## 実装
- Usersコントローラーにedit・updateアクション追加
- form_withを使用してフォームを実装する。ラベルは以下
  - name(名前)
  - email(メールアドレス)
  - avatar(アバター画像)
- 正しく入力できた時、マイページに遷移するように設定

## 確認
- [x] 名前・メールアドレスが未入力の時、エラーが表示されるか
- [x] 既に登録されているメールアドレスを入力した時、エラーが表示されるか
- [x] 正しく入力された時、マイページに遷移するか

## やらなかったこと
- パスワード変更機能

## ゴール
ユーザーの名前・メールアドレス・アバターが変更できるようになる