### PR TITLE
ユーザー投稿一覧作成

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -39,6 +39,10 @@ class PostsController < ApplicationController
     redirect_to posts_path, status: :see_other
   end
 
+  def user_index
+    @posts = Post.where(user_id: params[:id]).order(created_at: :desc)
+  end
+
   private
 
   def post_params

--- a/app/views/posts/user_index.html.erb
+++ b/app/views/posts/user_index.html.erb
@@ -1,0 +1,12 @@
+<section class="py-10 md:py-20">
+  <div class="mx-auto max-w-xl px-5 md:max-w-3xl lg:max-w-5xl">
+    <h2 class="text-3xl font-bold text-center md:text-4xl"><%= t('.title') %></h2>
+    <% if @posts.present? %>
+      <div class="grid grid-cols-1 gap-5 mt-10 md:grid-cols-2 md:gap-10 lg:grid-cols-3">
+        <%= render @posts %>
+      </div>
+    <% else %>
+      <p class="mt-10 text-lg text-center md:mt-20"><%= t('.no_post') %></p>
+    <% end %>
+  </div>
+</section>

--- a/app/views/shared/_login_header.html.erb
+++ b/app/views/shared/_login_header.html.erb
@@ -22,7 +22,7 @@
       <%= link_to t('header.my_page'), user_path(current_user), class: 'block p-3 text-white text-center hover:underline' %>
     </li>
     <li>
-      <%= link_to t('header.my_post_index'), '', class: 'block p-3 text-white text-center hover:underline' %>
+      <%= link_to t('header.my_post_index'), user_index_post_path(current_user), class: 'block p-3 text-white text-center hover:underline' %>
     </li>
     <li>
       <%= link_to  t('header.bookmark_index'), '', class: 'block p-3 text-white text-center hover:underline' %>
@@ -46,7 +46,7 @@
       <%= link_to t('header.my_page'), user_path(current_user), class: 'block p-3 text-white text-center' %>
     </li>
     <li>
-      <%= link_to t('header.my_post_index'), '', class: 'block p-3 text-white text-center' %>
+      <%= link_to t('header.my_post_index'), user_index_post_path(current_user), class: 'block p-3 text-white text-center' %>
     </li>
     <li>
       <%= link_to  t('header.bookmark_index'), '', class: 'block p-3 text-white text-center' %>

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -43,3 +43,6 @@ ja:
       title: コード登録
     edit:
       title: コード編集
+    user_index:
+      title: マイコード一覧
+      no_post: 現在、投稿がありません

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,11 @@ Rails.application.routes.draw do
   }
   root "static_pages#top"
   resources :users, only: %i[show]
-  resources :posts, only: %i[index new create show edit update destroy]
+  resources :posts, only: %i[index new create show edit update destroy] do
+    member do
+      get 'user_index'
+    end
+  end
 
   get "up" => "rails/health#show", as: :rails_health_check
 end


### PR DESCRIPTION
close #56 

# 概要
ユーザーが登録したコード一覧を閲覧できるようにするため、ルーティングとリンクの設定をする

## 実装
- ユーザー一覧用のルーティングをmemberを使用して設定する
- ヘッダーのメニューにユーザーコード一覧へのリンクを設定する

## 確認
- [x] ヘッダーのメニューからユーザーコード一覧ページに遷移できるか
- [x] 自分の登録したコード一覧が適切に表示されているか
- [x] 別のユーザーの投稿が表示されていないか

## ゴール
ユーザーがヘッダーのメニューから自分の登録したコード一覧が閲覧できるようになる