### PR TITLE
フラッシュメッセージ機能追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
+  add_flash_types :success, :danger
 
   protected
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,13 +1,3 @@
 class ApplicationController < ActionController::Base
-  before_action :configure_permitted_parameters, if: :devise_controller?
   add_flash_types :success, :danger
-
-  protected
-
-  def configure_permitted_parameters
-    # サインアップ時にnameのストロングパラメータを追加
-    devise_parameter_sanitizer.permit(:sign_up, keys: %i[name])
-    # アカウント編集時にnameのストロングパラメータを追加
-    devise_parameter_sanitizer.permit(:account_update, keys: %i[name avatar avatar_cache])
-  end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -10,8 +10,9 @@ class PostsController < ApplicationController
   def create
     @post = current_user.posts.build(post_params)
     if @post.save
-      redirect_to posts_path
+      redirect_to posts_path, success: t('defaults.flash_message.created', item: Post.model_name.human)
     else
+      flash.now[:danger] = t('defaults.flash_message.not_created', item: Post.model_name.human)
       render :new, status: :unprocessable_entity
     end
   end
@@ -27,8 +28,9 @@ class PostsController < ApplicationController
   def update
     @post = current_user.posts.find(params[:id])
     if @post.update(post_params)
-      redirect_to post_path(@post)
+      redirect_to post_path(@post), success: t('defaults.flash_message.updated', item: Post.model_name.human)
     else
+      flash.now[:danger] = t('defaults.flash_message.not_updated', item: Post.model_name.human)
       render :edit, status: :unprocessable_entity
     end
   end
@@ -36,7 +38,7 @@ class PostsController < ApplicationController
   def destroy
     @post = current_user.posts.find(params[:id])
     @post.destroy!
-    redirect_to posts_path, status: :see_other
+    redirect_to posts_path, success: t('defaults.flash_message.destroyed', item: Post.model_name.human), status: :see_other
   end
 
   def user_index

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,28 +1,40 @@
 # frozen_string_literal: true
 
 class Users::RegistrationsController < Devise::RegistrationsController
-  # before_action :configure_sign_up_params, only: [:create]
-  # before_action :configure_account_update_params, only: [:update]
+  before_action :configure_sign_up_params, only: [:create]
+  before_action :configure_account_update_params, only: [:update]
 
   # GET /resource/sign_up
-  # def new
-  #   super
-  # end
+  def new
+    @user = User.new
+  end
 
   # POST /resource
-  # def create
-  #   super
-  # end
+  def create
+    @user = User.new(sign_up_params)
+    if @user.save
+      redirect_to new_user_session_path, success: t('defaults.flash_message.created', item: User.model_name.human)
+    else
+      flash.now[:danger] = t('defaults.flash_message.not_created', item: User.model_name.human)
+      render :new, status: :unprocessable_entity
+    end
+  end
 
   # GET /resource/edit
-  # def edit
-  #   super
-  # end
+  def edit
+    super
+  end
 
   # PUT /resource
-  # def update
-  #   super
-  # end
+  def update
+    @user = current_user
+    if @user.update(account_update_params)
+      redirect_to user_path(@user), success: t('defaults.flash_message.updated', item: User.model_name.human)
+    else
+      flash.now[:danger] = t('defaults.flash_message.not_updated', item: User.model_name.human)
+      render :edit, status: :unprocessable_entity
+    end
+  end
 
   # DELETE /resource
   # def destroy
@@ -49,15 +61,15 @@ class Users::RegistrationsController < Devise::RegistrationsController
     user_path(current_user)
   end
 
-  # If you have extra params to permit, append them to the sanitizer.
-  # def configure_sign_up_params
-  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
-  # end
+  # サインアップ時のストロングパラメータを追加（デフォルトに加えて）
+  def configure_sign_up_params
+    devise_parameter_sanitizer.permit(:sign_up, keys: %i[name])
+  end
 
-  # If you have extra params to permit, append them to the sanitizer.
-  # def configure_account_update_params
-  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
-  # end
+  # アカウント編集時のストロングパラメータを追加（デフォルトに加えて）
+  def configure_account_update_params
+    devise_parameter_sanitizer.permit(:account_update, keys: %i[name avatar avatar_cache])
+  end
 
   # The path used after sign up.
   # def after_sign_up_path_for(resource)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,7 @@
       <%= render 'shared/before_login_header' %>
     <% end %>
 
+    <%= render 'shared/flash_message' %>
 
     <main class="flex-1">
       <%= yield %>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,5 @@
+<% flash.each do |message_type, message| %>
+  <div class="<%= message_type == 'success' ? 'bg-green-100' : 'bg-red-100' %>">
+    <%= content_tag :p, message, class: "p-5 text-base font-medium md:text-lg" %>
+  </div>
+<% end %>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,5 +1,5 @@
 <% flash.each do |message_type, message| %>
-  <div class="<%= message_type == 'success' ? 'bg-green-100' : 'bg-red-100' %>">
+  <div class="<%= message_type == 'success' || message_type == 'notice' ? 'bg-green-100' : 'bg-red-100' %>">
     <%= content_tag :p, message, class: "p-5 text-base font-medium md:text-lg" %>
   </div>
 <% end %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -2,6 +2,7 @@ ja:
   activerecord:
     models:
       user: ユーザー
+      post: 投稿
     attributes:
       user:
         name: 名前

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -1,6 +1,13 @@
 ja:
   defaults:
     delete_confirm: 削除しますか？
+    flash_message:
+      require_login: ログインしてください
+      created: "%{item}を登録しました"
+      not_created: "%{item}を登録出来ませんでした"
+      updated: "%{item}を更新しました"
+      not_updated: "%{item}を更新出来ませんでした"
+      destroyed: "%{item}を削除しました"
   helper:
     submit:
       create: 登録する


### PR DESCRIPTION
close #58 

# 概要
ユーザーが行ったことを分かりやすくするため、フラッシュメッセージを作成する

## 実装
- ユーザーが以下の動作を行った時、フラッシュメッセージが出るように設定
  - 新規登録
  - ログイン
  - 新規投稿
  - 投稿編集
  - 投稿削除

## 確認
- [x] 新規登録の成功・失敗時にフラッシュメッセージは出ているか
- [x] ログインの成功・失敗時にフラッシュメッセージは出ているか
- [x] ログアウトの成功時にフラッシュメッセージは出ているか
- [x] 新規投稿の成功・失敗時にフラッシュメッセージは出ているか
- [x] 投稿編集の成功・失敗時にフラッシュメッセージは出ているか
- [x] 投稿削除の成功・失敗時にフラッシュメッセージは出ているか

## ゴール
ユーザーが上記の動作を行った時、フラッシュメッセージが正常に出ている