### PR TITLE
フォームのラベルに必須マーク追加

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -72,4 +72,14 @@
   .js-user-menu.is-open {
     transform: translateX(0);
   }
+
+  /* フォームラベルの必須マーク */
+  .required::after {
+    display: inline-block;
+    margin-left: 4px;
+    content: '*';
+    color: #ef4444;
+    font-size: 20px;
+    font-weight: 400;
+  }
 }

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -7,12 +7,12 @@
 
       <div class="grid grid-cols-1 gap-5">
         <div>
-          <%= f.label :name, class: 'inline-block text-base md:text-lg' %>
+          <%= f.label :name, class: 'inline-block text-base md:text-lg required' %>
           <%= f.text_field :name, autofocus: true, autocomplete: "name", class: 'block mt-2 rounded w-full p-2 bg-white text-base md:px-4 md:py-3' %>
         </div>
 
         <div>
-          <%= f.label :email, class: 'inline-block text-base md:text-lg' %>
+          <%= f.label :email, class: 'inline-block text-base md:text-lg required' %>
           <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'block mt-2 rounded w-full p-2 bg-white text-base md:px-4 md:py-3' %>
         </div>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -6,17 +6,17 @@
 
       <div class="grid grid-cols-1 gap-5">
         <div>
-          <%= f.label :name, class: 'inline-block text-base md:text-lg' %>
+          <%= f.label :name, class: 'inline-block text-base md:text-lg required' %>
           <%= f.text_field :name, autofocus: true, autocomplete: "name", class: 'block mt-2 rounded w-full p-2 bg-white text-base md:px-4 md:py-3' %>
         </div>
 
         <div>
-          <%= f.label :email, class: 'inline-block text-base md:text-lg' %>
+          <%= f.label :email, class: 'inline-block text-base md:text-lg required' %>
           <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'block mt-2 rounded w-full p-2 bg-white text-base md:px-4 md:py-3' %>
         </div>
 
         <div>
-          <%= f.label :password, class: 'inline-block text-base md:text-lg' %>
+          <%= f.label :password, class: 'inline-block text-base md:text-lg required' %>
             <% if @minimum_password_length %>
               <em><%= t("devise.shared.minimum_password_length", count: @minimum_password_length) %></em>
             <% end %>
@@ -24,7 +24,7 @@
         </div>
 
         <div>
-          <%= f.label :password_confirmation, class: 'inline-block text-base md:text-lg' %>
+          <%= f.label :password_confirmation, class: 'inline-block text-base md:text-lg required' %>
           <%= f.password_field :password_confirmation, autocomplete: "new-password", class: 'block mt-2 rounded w-full p-2 bg-white text-base md:px-4 md:py-3' %>
         </div>
       </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -4,12 +4,12 @@
     <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: 'mt-10' }) do |f| %>
       <div class="grid grid-cols-1 gap-5">
         <div>
-          <%= f.label :email, class: 'inline-block text-base md:text-lg' %>
+          <%= f.label :email, class: 'inline-block text-base md:text-lg required' %>
           <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'block mt-2 rounded w-full p-2 bg-white text-base md:px-4 md:py-3' %>
         </div>
 
         <div>
-          <%= f.label :password, class: 'inline-block text-base md:text-lg' %>
+          <%= f.label :password, class: 'inline-block text-base md:text-lg required' %>
           <%= f.password_field :password, autocomplete: "current-password", class: 'block mt-2 rounded w-full p-2 bg-white text-base md:px-4 md:py-3' %>
         </div>
 

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with model: @post, class: 'grid grid-cols-1 gap-5 mt-10' do |f| %>
   <div>
-    <%= f.label :title, class: 'inline-block text-base md:text-lg' %>
+    <%= f.label :title, class: 'inline-block text-base md:text-lg required' %>
     <%= f.text_field :title, autofocus: true, class: 'block mt-2 rounded w-full p-2 bg-white text-base md:px-4 md:py-3' %>
   </div>
 


### PR DESCRIPTION
close #82

# 概要
フォームの必須項目に*をつける

## 実装
- CSSを使用してフォームラベルの後ろに*マークを実装

## 確認
- [x] 新規登録の必須項目に*マークが付いているか
  - [x] 名前
  - [x] メールアドレス
  - [x] パスワード
  - [x] パスワード確認
- [x] ログインの必須項目に*マークが付いているか
  - [x] メールアドレス
  - [x] パスワード
- [x] コード登録の必須項目に*マークが付いているか
  - [x] タイトル
- [x] コード編集の必須項目に*マークが付いているか
  - [x] タイトル

## ゴール
上記のフォームラベルに*マークが付いている