### PR TITLE
フォームの失敗時にエラーメッセージを表示

### DIFF
--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,11 +1,5 @@
 <% if resource.errors.any? %>
   <div id="error_explanation" class="mb-5" data-turbo-cache="false">
-    <h2>
-      <%= I18n.t("errors.messages.not_saved",
-                 count: resource.errors.count,
-                 resource: resource.class.model_name.human.downcase)
-       %>
-    </h2>
     <ul class="pl-5">
       <% resource.errors.full_messages.each do |message| %>
         <li class="list-disc text-red-500 text-base"><%= message %></li>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,4 +1,5 @@
 <%= form_with model: @post, class: 'grid grid-cols-1 gap-5 mt-10' do |f| %>
+  <%= render 'shared/error_message', object: f.object %>
   <div>
     <%= f.label :title, class: 'inline-block text-base md:text-lg required' %>
     <%= f.text_field :title, autofocus: true, class: 'block mt-2 rounded w-full p-2 bg-white text-base md:px-4 md:py-3' %>

--- a/app/views/shared/_error_message.html.erb
+++ b/app/views/shared/_error_message.html.erb
@@ -1,0 +1,7 @@
+<% if object.errors.any? %>
+  <ul class="pl-5">
+    <% object.errors.each do |error| %>
+      <li class="list-disc text-red-500 text-base"><%= error.full_message %></li>
+    <% end %>
+  </ul>
+<% end %>


### PR DESCRIPTION
close #84 

# 概要
各フォームで失敗した時のエラーメッセージを表示させる。
また、userとpostでエラーのレイアウトを統一させる。

## 実装
- 投稿関連のフォームにエラーメッセージを追加する
- ユーザーと投稿のフォームのエラーメッセージのCSSを調整する

## 確認
- [x] 各フォームでエラーメッセージが表示されているか
  - [x] 新規登録
  - [x] 新規投稿
  - [x] 投稿編集
  - [x] ユーザー編集

## ゴール
各フォームで失敗した時にエラーメッセージが表示されている