### PR TITLE
codeモデル作成

### DIFF
--- a/app/models/code.rb
+++ b/app/models/code.rb
@@ -1,0 +1,8 @@
+class Code < ApplicationRecord
+  belongs_to :user
+  belongs_to :post
+
+  enum language: { html: 0, css: 1, javascript: 2, ruby: 3, php: 4 }
+
+  validates :body, presence: true
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,4 +1,5 @@
 class Post < ApplicationRecord
+  has_many :codes, dependent: :destroy
   belongs_to :user
 
   validates :title, presence: true, length: { maximum: 100 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   has_many :posts, dependent: :destroy
+  has_many :codes, dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 100 }
   # Include default devise modules. Others available are:

--- a/db/migrate/20240729124816_create_codes.rb
+++ b/db/migrate/20240729124816_create_codes.rb
@@ -1,0 +1,12 @@
+class CreateCodes < ActiveRecord::Migration[7.1]
+  def change
+    create_table :codes do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :post, null: false, foreign_key: true
+      t.integer :language, null: false, default: 0
+      t.text :body, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_26_103740) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_29_124816) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "codes", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.integer "language", default: 0, null: false
+    t.text "body", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_codes_on_post_id"
+    t.index ["user_id"], name: "index_codes_on_user_id"
+  end
 
   create_table "posts", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -39,5 +50,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_26_103740) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "codes", "posts"
+  add_foreign_key "codes", "users"
   add_foreign_key "posts", "users"
 end


### PR DESCRIPTION
# 概要
コードの登録機能を実装するため、Codeモデルを作成する

## パス
`app/models/code.rb`

## attribute
- language(string)
- body(text)

## 制約
- language：nullを許容しない
- body：nullを許容しない

## 変更点
- enumを使用するため、language(string) → language(integer)に変更

## 確認
- [x] Users(1)：Codes(多)のリレーションが出来ている
- [x] Posts(1)：Codes(多)のリレーションが出来ている
- [x] language：nullを許容しない
- [x] body：nullを許容しない

## ゴール
db/schema.rbに上記のカラムがあるCodesテーブルが生成されている