### PR TITLE
投稿にコードコード登録機能を追加

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -5,6 +5,7 @@ class PostsController < ApplicationController
 
   def new
     @post = Post.new
+    @post.codes.build
   end
 
   def create
@@ -18,7 +19,7 @@ class PostsController < ApplicationController
   end
 
   def show
-    @post = Post.find(params[:id])
+    @post = Post.includes(:codes).find(params[:id])
   end
 
   def edit
@@ -48,6 +49,6 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:title, :description, :image, :image_cache)
+    params.require(:post).permit(:title, :description, :image, :image_cache, codes_attributes: [:id, :language, :body, :_destroy])
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
   def index
-    @posts = Post.all.order(created_at: :desc)
+    @posts = Post.includes(:user).order(created_at: :desc)
   end
 
   def new
@@ -42,7 +42,7 @@ class PostsController < ApplicationController
   end
 
   def user_index
-    @posts = Post.where(user_id: params[:id]).order(created_at: :desc)
+    @posts = Post.includes(:user).where(user_id: params[:id]).order(created_at: :desc)
   end
 
   private

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,14 @@
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
+
+  # 指定された属性名と値を人間が読みやすい形式の属性名を返す
+  def self.human_attribute_enum_value(attr_name, value)
+    return if value.blank?
+    human_attribute_name("#{attr_name}.#{value}")
+  end
+
+  # 指定された列挙型の属性名に基づき、その選択肢をハッシュに変換
+  def self.enum_options_for_select(attr_name)
+    self.send(attr_name.to_s.pluralize).map { |k, _| [self.human_attribute_enum_value(attr_name, k), k] }.to_h
+  end
 end

--- a/app/models/code.rb
+++ b/app/models/code.rb
@@ -1,5 +1,4 @@
 class Code < ApplicationRecord
-  belongs_to :user
   belongs_to :post
 
   enum language: { html: 0, css: 1, javascript: 2, ruby: 3, php: 4 }

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,5 +1,6 @@
 class Post < ApplicationRecord
   has_many :codes, dependent: :destroy
+  accepts_nested_attributes_for :codes
   belongs_to :user
 
   validates :title, presence: true, length: { maximum: 100 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,5 @@
 class User < ApplicationRecord
   has_many :posts, dependent: :destroy
-  has_many :codes, dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 100 }
   # Include default devise modules. Others available are:

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @post, class: 'grid grid-cols-1 gap-5 mt-10' do |f| %>
+<%= form_with model: @post, class: 'grid grid-cols-1 gap-5 mt-10 md:gap-10' do |f| %>
   <%= render 'shared/error_message', object: f.object %>
   <div>
     <%= f.label :title, class: 'inline-block text-base md:text-lg required' %>
@@ -15,6 +15,22 @@
     <%= f.file_field :image, class: 'block mt-2 w-full text-base', accept: 'image/*' %>
     <%= f.hidden_field :image_cache %>
   </div>
+
+  <%= f.fields_for :codes do |c| %>
+    <div class="flex flex-col items-start gap-2">
+      <%= c.label :language, class: 'inline-block text-base md:text-lg' %>
+      <%= c.select :language, Code.enum_options_for_select(:language), {}, { class: 'p-4 text-base' } %>
+    </div>
+
+    <div class="field">
+      <%= c.label :body, class: 'inline-block text-base md:text-lg required' %>
+      <%= c.text_area :body, class: 'block mt-2 w-full min-h-[400px] p-2' %>
+    </div>
+
+    <div class="field">
+      <%= link_to "Remove", '#', class: "remove_fields" %>
+    </div>
+  <% end %>
 
   <div class="mt-10 text-center">
     <%= f.submit nil, class: 'inline-block rounded max-w-[160px] w-full p-3 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70' %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -10,6 +10,13 @@
       <%= image_tag @post.image_url, class: 'w-full max-h-[800px] object-contain' %>
     </div>
 
+    <% @post.codes.each do |code| %>
+      <div class="flex flex-col gap-2">
+        <p class="mt-5 text-xl font-bold md:mt-10"><%= t("activerecord.attributes.code/language.#{code.language}") %></p>
+        <code class="p-5 bg-white"><%= code.body %></code>
+      </div>
+    <% end %>
+
     <% if current_user.own?(@post) %>
       <div class="flex justify-center gap-5 mt-10">
         <%= link_to t('helper.submit.edit'), edit_post_path(@post), class: 'inline-block rounded max-w-[160px] w-full p-3 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70' %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -11,3 +11,14 @@ ja:
         title: タイトル
         description: コード説明
         image: サムネイル
+      code:
+        language: 言語
+        body: コード
+      codes:
+        body: コード
+      code/language:
+        html: HTML
+        css: CSS
+        javascript: JavaScript
+        ruby: Ruby
+        php: PHP

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
     member do
       get 'user_index'
     end
+
+    resources :codes
   end
 
   get "up" => "rails/health#show", as: :rails_health_check

--- a/db/migrate/20240729124816_create_codes.rb
+++ b/db/migrate/20240729124816_create_codes.rb
@@ -1,7 +1,6 @@
 class CreateCodes < ActiveRecord::Migration[7.1]
   def change
     create_table :codes do |t|
-      t.references :user, null: false, foreign_key: true
       t.references :post, null: false, foreign_key: true
       t.integer :language, null: false, default: 0
       t.text :body, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,14 +15,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_29_124816) do
   enable_extension "plpgsql"
 
   create_table "codes", force: :cascade do |t|
-    t.bigint "user_id", null: false
     t.bigint "post_id", null: false
     t.integer "language", default: 0, null: false
     t.text "body", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["post_id"], name: "index_codes_on_post_id"
-    t.index ["user_id"], name: "index_codes_on_user_id"
   end
 
   create_table "posts", force: :cascade do |t|
@@ -51,6 +49,5 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_29_124816) do
   end
 
   add_foreign_key "codes", "posts"
-  add_foreign_key "codes", "users"
   add_foreign_key "posts", "users"
 end


### PR DESCRIPTION
close #51 

# 概要
投稿にコードを登録できるようにするため、Codesコントローラー作成及びcreateアクションを追加

## パス
`app/controllers/codes_controller.rb`

## 実装
- Codesコントローラーにcreateアクション追加
- `app/views/posts/new.html.erb`のフォームに言語・コードのフォームを追加

## 追加実装
- 詳細ページにコードを反映

## 確認
- [x] 未入力の時、エラーが出るか
- [x] 正しく投稿できた時、言語とコードがDBに反映されているか
- [x] 詳細ページに言語とコードが表示されているか

- エディター機能・コードハイライト機能は後で実装するので、コードが表示されていれば良い

## ゴール
新規投稿にコードが登録できるようになる