### PR TITLE
highlight.js導入

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,8 +6,12 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/vs2015.min.css">
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+    <script>document.addEventListener("turbo:load", () => { hljs.highlightAll(); });</script>
+    <script>document.addEventListener("DOMContentLoaded", () => { hljs.highlightAll(); });</script>
   </head>
 
   <body data-logged-in="<%= user_signed_in? %>">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -12,8 +12,10 @@
 
     <% @post.codes.each do |code| %>
       <div class="flex flex-col gap-2">
-        <p class="mt-5 text-xl font-bold md:mt-10"><%= t("activerecord.attributes.code/language.#{code.language}") %></p>
-        <code class="p-5 bg-white"><%= code.body %></code>
+        <p class="mt-5 text-xl font-bold md:mt-10 md:text-2xl"><%= t("activerecord.attributes.code/language.#{code.language}") %></p>
+        <pre class="-mt-5">
+          <code class="h-full"><%= code.body %></code>
+        </pre>
       </div>
     <% end %>
 


### PR DESCRIPTION
close #53 

# 概要
highlight.jsを導入して投稿詳細のコード部分がハイライト機能を実装する

## パス
`app/views/posts/show.html.erb`

## 実装
- highlight.jsをyarnでインストールして読み込むように設定
- 投稿詳細のコード部分をpreタグ・codeタグで囲む

## 確認
- [x] highlight.jsが正しくインストールされているか
- [x] 投稿詳細のコードがハイライトされているか
- [x] 複数の言語でハイライトされているか

## ゴール
投稿詳細のコードがハイライト表示されている

## 参考
[highlight.js](https://highlightjs.org/)