### PR TITLE
画像をamazonS3に保存する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,12 @@ gem "rails-i18n"
 # 画像のアップロード
 gem 'carrierwave', '~> 3.0'
 
+# ファイルの保存先を外部のストレージする際にサポート
+gem 'fog-aws'
+
+# 環境変数を管理
+gem 'dotenv-rails'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,14 +117,35 @@ GEM
       warden (~> 1.2.3)
     devise-i18n (1.12.1)
       devise (>= 4.9.0)
+    dotenv (3.1.2)
+    dotenv-rails (3.1.2)
+      dotenv (= 3.1.2)
+      railties (>= 6.1)
     drb (2.2.1)
     erubi (1.13.0)
+    excon (0.111.0)
     ffi (1.17.0-aarch64-linux-gnu)
     ffi (1.17.0-arm-linux-gnu)
     ffi (1.17.0-arm64-darwin)
     ffi (1.17.0-x86-linux-gnu)
     ffi (1.17.0-x86_64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
+    fog-aws (3.24.0)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+    fog-core (2.4.0)
+      builder
+      excon (~> 0.71)
+      formatador (>= 0.2, < 2.0)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.4)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    formatador (1.1.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.5)
@@ -152,10 +173,14 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    mime-types (3.5.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2024.0702)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.24.1)
     msgpack (1.7.2)
+    multi_json (1.15.0)
     mutex_m (0.2.0)
     net-imap (0.4.14)
       date
@@ -300,6 +325,8 @@ DEPENDENCIES
   debug
   devise
   devise-i18n
+  dotenv-rails
+  fog-aws
   jbuilder
   jsbundling-rails
   pg (~> 1.1)

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -4,8 +4,8 @@ class AvatarUploader < CarrierWave::Uploader::Base
   # include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
+  # storage :file
+  storage :fog
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -4,8 +4,8 @@ class ImageUploader < CarrierWave::Uploader::Base
   # include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
+  # storage :file
+  storage :fog
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/config/initializers/carrierwava.rb
+++ b/config/initializers/carrierwava.rb
@@ -1,0 +1,16 @@
+require 'carrierwave/storage/abstract'
+require 'carrierwave/storage/file'
+require 'carrierwave/storage/fog'
+
+CarrierWave.configure do |config|
+    config.storage :fog
+    config.fog_provider = 'fog/aws'
+    config.fog_directory  = 'code-sheet-image' # 作成したバケット名を記述
+    config.fog_credentials = {
+      provider: 'AWS',
+      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'], # 環境変数
+      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'], # 環境変数
+      region: 'ap-northeast-1',   # アジアパシフィック(東京)を選択した場合
+      path_style: true
+    }
+end


### PR DESCRIPTION
close #60 

# 概要
投稿の画像でサーバーの容量を圧迫しないため、AmazonS3にアップロードするように設定

## 実装
- gem `fog-aws`・`dotenv-rails`をインストール
- AWSの設定(詳しくは下記の参考URLを参照)
- アップローダーのストレージを変更
- `carrierwave.rb`ファイルを作成およびIAMユーザーとバケットの情報を設定
- `.env`ファイルを作成および環境変数の設定

## 確認
- [x] 投稿の画像がAmazonS3に正常にアップロードされているか
- [x] gem fog-awsはインストールされているか
- [x] gem dotenv-railsはインストールされているか
- [x] AWSのアクセスキーは環境変数が使われているか

## ゴール
投稿された画像がAmazonS3にアップロードされている

## 参考URL
[CarrierWaveチュートリアル](https://pikawaka.com/rails/carrierwave)