### PR TITLE
投稿詳細コードのコピー機能

### DIFF
--- a/app/javascript/controllers/code_copy_controller.js
+++ b/app/javascript/controllers/code_copy_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["code"];
+
+  copy(event) {
+    const buttonElement = event.currentTarget;
+    const codeElement = buttonElement.closest('.code-container').querySelector('code');
+    const codeText = codeElement.innerText;
+
+    navigator.clipboard.writeText(codeText).then(() => {
+      alert("コードをコピーしました！");
+    }).catch(error => {
+      console.error('Failed to copy: ', error);
+    });
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -3,6 +3,8 @@
 // ./bin/rails generate stimulus controllerName
 
 import { application } from "./application"
+import CodeCopyController from "./code_copy_controller"
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+application.register("code-copy", CodeCopyController)

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -11,18 +11,21 @@
     </div>
 
     <% @post.codes.each do |code| %>
-      <div class="flex flex-col gap-2">
+      <div class="flex flex-col gap-2 code-container" data-controller="code-copy">
         <p class="mt-5 text-xl font-bold md:mt-10 md:text-2xl"><%= t("activerecord.attributes.code/language.#{code.language}") %></p>
         <pre class="-mt-5">
-          <code class="h-full"><%= code.body %></code>
+          <code class="h-full" data-code-copy-target="code"><%= code.body %></code>
         </pre>
+        <div class="-mt-5 text-center">
+          <button type="button" data-action="click->code-copy#copy" class="inline-block rounded max-w-[160px] w-full p-3 bg-green-500 text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70">コピー</button>
+        </div>
       </div>
     <% end %>
 
     <% if current_user.own?(@post) %>
       <div class="flex justify-center gap-5 mt-10">
         <%= link_to t('helper.submit.edit'), edit_post_path(@post), class: 'inline-block rounded max-w-[160px] w-full p-3 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70' %>
-        <%= link_to t('helper.submit.destroy'), post_path(@post), class: 'inline-block rounded max-w-[160px] w-full p-3 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70', data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } %>
+        <%= link_to t('helper.submit.destroy'), post_path(@post), class: 'inline-block rounded max-w-[160px] w-full p-3 bg-red-500 text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70', data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } %>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
# 概要
現時点ではコードをコピーできないので、投稿詳細のコードをコピーできるようにする

## パス
`app/views/posts/show.html.erb`

## 実装
- JavaScriptを使用してコードをクリックイベントを作成

## 確認
- [x] コードをクリックした時にコピーができているか
- [x] VSCodeにペーストした時、インデントがずれていないか

## ゴール
投稿詳細のコードをコピーすることができ、VSCodeにペーストができている