### PR TITLE
投稿詳細ページのエラー修正

### DIFF
--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -5,10 +5,10 @@
       <span class="inline-block flex-shrink-0 rounded-full px-2 py-1 bg-sub-color text-white text-sm">カテゴリー</span>
       <time class="text-base font-normal" datetime="<%= l @post.created_at, format: :datetime %>"><%= l @post.created_at %></time>
     </div>
-    <p class="mt-5 text-base md:mt-10 md:text-lg"><%= @post.description %></p>
+    <p class="mt-5 text-base whitespace-pre-wrap md:mt-10 md:text-lg"><%= @post.description %></p>
     <% if @post.image_url.present? %>
       <div class="mt-5 mx-auto max-w-xl md:mt-10">
-        <%= image_tag @post.image_url, class: 'w-full max-h-[800px] object-contain' %>
+        <%= image_tag @post.image_url, class: 'mx-auto max-w-full max-h-[300px] object-contain' %>
       </div>
     <% end %>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -24,7 +24,7 @@
       </div>
     <% end %>
 
-    <% if current_user.own?(@post) %>
+    <% if current_user&.own?(@post) %>
       <div class="flex justify-center gap-5 mt-10">
         <%= link_to t('helper.submit.edit'), edit_post_path(@post), class: 'inline-block rounded max-w-[160px] w-full p-3 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70' %>
         <%= link_to t('helper.submit.destroy'), post_path(@post), class: 'inline-block rounded max-w-[160px] w-full p-3 bg-red-500 text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70', data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } %>


### PR DESCRIPTION
# 概要
ログインしていないユーザーが投稿詳細ページを閲覧できないのを修正

## 修正点
- 投稿詳細のエラーを解除
- 投稿詳細のCSSを若干修正