### PR TITLE
コードの複数登録

### DIFF
--- a/app/javascript/controllers/change_form_controller.js
+++ b/app/javascript/controllers/change_form_controller.js
@@ -17,24 +17,26 @@ export default class extends Controller {
     let codeFormElement = document.createElement('div');
     codeFormElement.innerHTML = `
       <div class="relative mt-5 md:mt-10 js-code">
-        <div class="js-form-code">
-          <div class="flex flex-col items-start gap-2">
-            <label class="inline-block text-base md:text-lg" for="post_codes_attributes_${this.codeId}_language">言語</label>
-            <select class="p-4 text-base" name="post[codes_attributes][${this.codeId}][language]" id="post_codes_attributes_${this.codeId}_language">
-              <option selected="selected" value="html">HTML</option>
-              <option value="css">CSS</option>
-              <option value="javascript">JavaScript</option>
-              <option value="ruby">Ruby</option>
-              <option value="php">PHP</option>
-            </select>
+        <div class="relative">
+          <div class="js-form-code">
+            <div class="flex flex-col items-start gap-2">
+              <label class="inline-block text-base md:text-lg" for="post_codes_attributes_${this.codeId}_language">言語</label>
+              <select class="p-4 text-base" name="post[codes_attributes][${this.codeId}][language]" id="post_codes_attributes_${this.codeId}_language">
+                <option selected="selected" value="html">HTML</option>
+                <option value="css">CSS</option>
+                <option value="javascript">JavaScript</option>
+                <option value="ruby">Ruby</option>
+                <option value="php">PHP</option>
+              </select>
+            </div>
+            <div class="mt-5 md:mt-10">
+              <label class="inline-block text-base md:text-lg required" for="post_codes_attributes_${this.codeId}_body">コード</label>
+              <textarea class="block mt-2 w-full min-h-[400px] p-2" name="post[codes_attributes][${this.codeId}][body]" id="post_codes_attributes_${this.codeId}_body"></textarea>
+            </div>
           </div>
-          <div class="mt-5 md:mt-10">
-            <label class="inline-block text-base md:text-lg required" for="post_codes_attributes_${this.codeId}_body">コード</label>
-            <textarea class="block mt-2 w-full min-h-[400px] p-2" name="post[codes_attributes][${this.codeId}][body]" id="post_codes_attributes_${this.codeId}_body"></textarea>
-          </div>
+          <input type="hidden" name="post[codes_attributes][${this.codeId}][_destroy]" value="false" class="destroy-flag">
+          <button type="button" data-action="click->change-form#remove" class="inline-block absolute bottom-[400px] right-0 rounded max-w-[90px] w-full p-2 bg-red-500 text-white text-sm font-bold text-center cursor-pointer">コード削除</button>
         </div>
-        <input type="hidden" name="post[codes_attributes][${this.codeId}][_destroy]" value="false" class="destroy-flag">
-        <button type="button" data-action="click->change-form#remove" class="inline-block absolute bottom-[400px] right-0 rounded max-w-[90px] w-full p-2 bg-red-500 text-white text-sm font-bold text-center cursor-pointer">コード削除</button>
       </div>
     `;
     const codeElements = document.querySelectorAll('.js-code');

--- a/app/javascript/controllers/change_form_controller.js
+++ b/app/javascript/controllers/change_form_controller.js
@@ -1,0 +1,61 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["formCode"];
+  codeId = document.querySelectorAll('.js-form-code').length;
+  maxForms = 3;
+
+  add() {
+    const currentFormsCount = document.querySelectorAll('.js-form-code').length;
+
+    if (currentFormsCount >= this.maxForms) {
+      alert('これ以上追加できません。');
+      return;
+    }
+
+    this.codeId++;
+    let codeFormElement = document.createElement('div');
+    codeFormElement.innerHTML = `
+      <div class="relative mt-5 md:mt-10 js-code">
+        <div class="js-form-code">
+          <div class="flex flex-col items-start gap-2">
+            <label class="inline-block text-base md:text-lg" for="post_codes_attributes_${this.codeId}_language">言語</label>
+            <select class="p-4 text-base" name="post[codes_attributes][${this.codeId}][language]" id="post_codes_attributes_${this.codeId}_language">
+              <option selected="selected" value="html">HTML</option>
+              <option value="css">CSS</option>
+              <option value="javascript">JavaScript</option>
+              <option value="ruby">Ruby</option>
+              <option value="php">PHP</option>
+            </select>
+          </div>
+          <div class="mt-5 md:mt-10">
+            <label class="inline-block text-base md:text-lg required" for="post_codes_attributes_${this.codeId}_body">コード</label>
+            <textarea class="block mt-2 w-full min-h-[400px] p-2" name="post[codes_attributes][${this.codeId}][body]" id="post_codes_attributes_${this.codeId}_body"></textarea>
+          </div>
+        </div>
+        <input type="hidden" name="post[codes_attributes][${this.codeId}][_destroy]" value="false" class="destroy-flag">
+        <button type="button" data-action="click->change-form#remove" class="inline-block absolute bottom-[400px] right-0 rounded max-w-[90px] w-full p-2 bg-red-500 text-white text-sm font-bold text-center cursor-pointer">コード削除</button>
+      </div>
+    `;
+    const codeElements = document.querySelectorAll('.js-code');
+    const lastCodeElement = codeElements[codeElements.length - 1];
+    lastCodeElement.appendChild(codeFormElement);
+  }
+
+  remove(event) {
+    const destroyFlag = event.currentTarget.previousElementSibling;
+    const formCodes = document.querySelectorAll('.js-form-code');
+    const formCodeElement = event.currentTarget.closest('.js-code').querySelector('.js-form-code');
+
+    if (formCodes.length <= 1) {
+      alert('これ以上削除できません。');
+      return;
+    }
+
+    if (destroyFlag) {
+      destroyFlag.value = 'true';
+      event.currentTarget.remove();
+      formCodeElement.remove();
+    }
+  }
+}

--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -1,7 +1,0 @@
-import { Controller } from "@hotwired/stimulus"
-
-export default class extends Controller {
-  connect() {
-    this.element.textContent = "Hello World!"
-  }
-}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,7 +4,7 @@
 
 import { application } from "./application"
 import CodeCopyController from "./code_copy_controller"
+import ChangeFormController from "./change_form_controller"
 
-import HelloController from "./hello_controller"
-application.register("hello", HelloController)
 application.register("code-copy", CodeCopyController)
+application.register("change-form", ChangeFormController)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,6 +1,6 @@
 class Post < ApplicationRecord
   has_many :codes, dependent: :destroy
-  accepts_nested_attributes_for :codes
+  accepts_nested_attributes_for :codes, allow_destroy: true
   belongs_to :user
 
   validates :title, presence: true, length: { maximum: 100 }

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -20,17 +20,31 @@
     <%= image_tag @post.image_url, class: 'w-64 object-contain' %>
   <% end %>
 
-  <%= f.fields_for :codes do |c| %>
-    <div class="flex flex-col items-start gap-2">
-      <%= c.label :language, class: 'inline-block text-base md:text-lg' %>
-      <%= c.select :language, Code.enum_options_for_select(:language), {}, { class: 'p-4 text-base' } %>
-    </div>
+  <div data-controller="change-form">
+    <%= f.fields_for :codes do |c| %>
+      <div class="mt-5 md:mt-10 js-code" data-change-form-target="form-code">
+        <div class="relative">
+          <div class="js-form-code">
+            <div class="flex flex-col items-start gap-2">
+              <%= c.label :language, class: 'inline-block text-base md:text-lg' %>
+              <%= c.select :language, Code.enum_options_for_select(:language), {}, { class: 'p-4 text-base' } %>
+            </div>
 
-    <div>
-      <%= c.label :body, class: 'inline-block text-base md:text-lg required' %>
-      <%= c.text_area :body, class: 'block mt-2 w-full min-h-[400px] p-2' %>
+            <div class="mt-5 md:mt-10">
+              <%= c.label :body, class: 'inline-block text-base md:text-lg required' %>
+              <%= c.text_area :body, class: 'block mt-2 w-full min-h-[400px] p-2' %>
+            </div>
+          </div>
+          <%= c.hidden_field :_destroy, class: 'destroy-flag' %>
+          <button type="button" data-action="click->change-form#remove" class="inline-block absolute bottom-[400px] right-0 rounded max-w-[90px] w-full p-2 bg-red-500 text-white text-sm font-bold text-center cursor-pointer">コード削除</button>
+        </div>
+      </div>
+    <% end %>
+
+    <div class="flex justify-center gap-5 mt-10">
+      <button type="button" data-action="click->change-form#add" class="inline-block rounded max-w-[160px] w-full p-3 bg-green-500 text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70">コード追加</button>
     </div>
-  <% end %>
+  </div>
 
   <div class="mt-10 text-center">
     <%= f.submit nil, class: 'inline-block rounded max-w-[160px] w-full p-3 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70' %>


### PR DESCRIPTION
# 概要
現時点ではコードが１つしか登録できないので、複数登録できるようにする

## パス
`app/views/posts/_form.html.erb`

## 実装
- コード登録箇所の下に追加・削除ボタンを追加
- JavaScriptでボタンを押した時にコード登録箇所を増加・削除できるように設定

## 確認
- [x] 追加ボタンを押すとコード登録が増えるか
- [x] 削除ボタンを押すとコード登録が削除されるか
- [x] コード登録が増えすぎないように設定されているか
- [ ] 登録箇所が１つの時に削除ボタンは消えているか
- [x] 編集ページでも追加されているコードが編集できるか
- [x] 追加されたコードが正常にDBに保存されているか

## 変更点
- 削除ボタンの位置をコードの右上に配置して、各コードを消せるように変更

## ゴール
新規投稿で複数のコードが登録できるようになる。