### PR TITLE
投稿一覧のカードリンク位置を修正

### DIFF
--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,13 +1,19 @@
-<%= link_to post_path(post), class: 'grid grid-rows-subgrid row-span-4 gap-5 pb-5 bg-white shadow-md duration-300 hover:shadow-xl hover:-translate-y-1.5' do %>
-  <% if post.image_url.present? %>
-    <%= image_tag post.image_url, class: 'w-full object-cover aspect-[300/200]' %>
-  <% else %>
-    <%= image_tag 'no_image.jpg', class: 'w-full object-cover aspect-[300/200]' %>
+<article class="grid grid-rows-subgrid row-span-4 gap-5 pb-5 bg-white shadow-lg overflow-hidden">
+  <%= link_to post_path(post), class: 'block group' do %>
+    <% if post.image_url.present? %>
+      <%= image_tag post.image_url, class: 'w-full object-cover aspect-[300/200] duration-300 group-hover:scale-110' %>
+    <% else %>
+      <%= image_tag 'no_image.jpg', class: 'w-full object-cover aspect-[300/200] duration-300 group-hover:scale-110' %>
+    <% end %>
   <% end %>
-  <h3 class="px-5 text-lg font-bold line-clamp-2"><%= post.title %></h3>
+  <h3 class="px-5 text-lg font-bold line-clamp-2">
+    <%= link_to post_path(post), class: 'hover:underline' do %>
+      <%= post.title %>
+    <% end %>
+  </h3>
   <div class="flex justify-between items-center gap-5 px-5">
     <span class="inline-block flex-shrink-0 rounded-full px-2 py-1 bg-sub-color text-white text-sm">カテゴリー</span>
     <time class="text-base font-normal" datetime="<%= l post.created_at, format: :datetime %>"><%= l post.created_at %></time>
   </div>
   <p class="px-5 text-base line-clamp-2"><%= post.description %></p>
-<% end %>
+</article>


### PR DESCRIPTION
close #103 

# 概要
一覧ページのカードにブックマーク機能といいね機能を実装するため、全体リンクから画像またはタイトルリンクに変更する。

## パス
`app/views/posts/_post.html.erb`

## 実装
- カードの全体リンクから画像またはタイトルにリンクを変更する

## 確認
- [x] カードの画像から詳細ページへ遷移できる
- [x] カードのタイトルから詳細ページへ遷移できる
- [x] カードの表示崩れがない

## ゴール
カードの画像またはタイトルから詳細ページへ遷移できる