### PR TITLE
投稿詳細のコピーボタン位置を修正

### DIFF
--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -15,11 +15,11 @@
     <% @post.codes.each do |code| %>
       <div class="flex flex-col gap-2 code-container" data-controller="code-copy">
         <p class="mt-5 text-xl font-bold md:mt-10 md:text-2xl"><%= t("activerecord.attributes.code/language.#{code.language}") %></p>
-        <pre class="-mt-5">
-          <code class="h-full" data-code-copy-target="code"><%= code.body %></code>
-        </pre>
-        <div class="-mt-5 text-center">
-          <button type="button" data-action="click->code-copy#copy" class="inline-block rounded max-w-[160px] w-full p-3 bg-green-500 text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70"><%= t('helper.submit.copy') %></button>
+        <div class="relative -mt-5">
+          <pre>
+            <code class="h-full" data-code-copy-target="code"><%= code.body %></code>
+          </pre>
+          <button type="button" data-action="click->code-copy#copy" class="inline-block absolute top-[-12px] right-0 rounded max-w-[110px] w-full p-2 bg-green-500 text-white text-sm font-bold text-center cursor-pointer"><%= t('helper.submit.copy') %></button>
         </div>
       </div>
     <% end %>

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -15,7 +15,7 @@ ja:
       save: 保存する
       edit: 編集する
       destroy: 削除する
-      copy: コードをコピー
+      copy: コードコピー
   header:
     title: CodeSheet
     login: ログイン


### PR DESCRIPTION
# 概要
ボタンが密集しており視認性が悪いのでコードコピーボタンの位置をコード右上に変更する。

## パス
`app/views/posts/show.html.erb`

## 実装
- CSSを調整してコピーボタンをコードの右上部分に配置する

## 確認
- [x] コピーボタンでコードがコピーできるか
- [x] コピーボタンがコードの右上に配置されているか
- [x] CSSの表示崩れはないか

## ゴール
コピーボタンがコードの右上に配置されており、コードがコピーできる