### PR TITLE
 非ログイン時一覧ページでのエラー修正

### DIFF
--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -15,9 +15,11 @@
       <%= post.title %>
     <% end %>
   </h3>
-  <% unless current_user.own?(post) %>
-    <div class="flex justify-end gap-5 px-5">
-      <%= render 'bookmark_buttons', { post: post } %>
-    </div>
+  <% if user_signed_in? %>
+    <% unless current_user.own?(post) %>
+      <div class="flex justify-end gap-5 px-5">
+        <%= render 'bookmark_buttons', { post: post } %>
+      </div>
+    <% end %>
   <% end %>
 </article>


### PR DESCRIPTION
close #111 

# 概要
非ログイン時に投稿が１つ以上されている状態で、一覧ページを開くとエラーが出るので修正する

## 実装
- ブックマーク機能実装時に非ログイン時の条件分岐を記述していないので追記する

## 確認
- [x] 非ログイン時に一覧ページが閲覧できる

## ゴール
エラーが修正されていて、非ログイン時に投稿一覧ページが閲覧できる。