### PR TITLE
ページネーション機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,9 @@ gem 'fog-aws'
 # 環境変数を管理
 gem 'dotenv-rails'
 
+# ページネーション
+gem 'kaminari'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,6 +162,18 @@ GEM
       activesupport (>= 5.0.0)
     jsbundling-rails (1.3.0)
       railties (>= 6.0.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     logger (1.6.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
@@ -329,6 +341,7 @@ DEPENDENCIES
   fog-aws
   jbuilder
   jsbundling-rails
+  kaminari
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.4)

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -90,4 +90,12 @@
     font-size: 20px;
     font-weight: 400;
   }
+
+  .current {
+    border-radius: 50%;
+    width: 24px;
+    height: 24px;
+    background-color: #1995AD;
+    color: #fff;
+  }
 }

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
   def index
-    @posts = Post.includes(:user).order(created_at: :desc)
+    @posts = Post.includes(:user).order(created_at: :desc).page(params[:page])
   end
 
   def new
@@ -43,11 +43,11 @@ class PostsController < ApplicationController
   end
 
   def user_index
-    @posts = Post.includes(:user).where(user_id: params[:id]).order(created_at: :desc)
+    @posts = Post.includes(:user).where(user_id: params[:id]).order(created_at: :desc).page(params[:page])
   end
 
   def bookmarks
-    @posts = current_user.bookmark_posts.order(created_at: :desc)
+    @posts = current_user.bookmark_posts.order(created_at: :desc).page(params[:page])
   end
 
   private

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "First" page
+  - available local variables
+    url:           url to the first page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="first">
+  <%= link_to_unless current_page.first?, t('pagination.first').html_safe, url, remote: remote, class: 'flex justify-center items-center w-6 h-6 text-lg font-bold' %>
+</span>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,8 @@
+<%# Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page gap flex justify-center items-center w-6 h-6 text-lg font-bold"><%= t('pagination.truncate').html_safe %></span>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Last" page
+  - available local variables
+    url:           url to the last page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="last">
+  <%= link_to_unless current_page.last?, t('pagination.last').html_safe, url, remote: remote, class: 'flex justify-center items-center w-6 h-6 text-lg font-bold' %>
+</span>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="next">
+  <%= link_to_unless current_page.last?, t('pagination.next').html_safe, url, rel: 'next', remote: remote, class: 'flex justify-center items-center w-6 h-6 text-lg font-bold' %>
+</span>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,12 @@
+<%# Link showing page number
+  - available local variables
+    page:          a page object for "this" page
+    url:           url to this page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page flex justify-center items-center w-6 h-6 text-lg font-bold<%= ' current' if page.current? %>">
+  <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel} %>
+</span>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,25 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
+<%= paginator.render do -%>
+  <nav class="pagination flex justify-center gap-3 mt-10 md:mt-20" role="navigation" aria-label="pager">
+    <%= first_page_tag unless current_page.first? %>
+    <%= prev_page_tag unless current_page.first? %>
+    <% each_page do |page| -%>
+      <% if page.display_tag? -%>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? -%>
+        <%= gap_tag %>
+      <% end -%>
+    <% end -%>
+    <% unless current_page.out_of_range? %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    <% end %>
+  </nav>
+<% end -%>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="prev">
+  <%= link_to_unless current_page.first?, t('pagination.previous').html_safe, url, rel: 'prev', remote: remote, class: 'flex justify-center items-center w-6 h-6 text-lg font-bold' %>
+</span>

--- a/app/views/posts/bookmarks.html.erb
+++ b/app/views/posts/bookmarks.html.erb
@@ -8,5 +8,7 @@
     <% else %>
       <p class="mt-10 text-lg text-center md:mt-20"><%= t('.no_post') %></p>
     <% end %>
+
+    <%= paginate @posts %>
   </div>
 </section>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -8,5 +8,7 @@
     <% else %>
       <p class="mt-10 text-lg text-center md:mt-20"><%= t('.no_post') %></p>
     <% end %>
+
+    <%= paginate @posts %>
   </div>
 </section>

--- a/app/views/posts/user_index.html.erb
+++ b/app/views/posts/user_index.html.erb
@@ -8,5 +8,7 @@
     <% else %>
       <p class="mt-10 text-lg text-center md:mt-20"><%= t('.no_post') %></p>
     <% end %>
+
+    <%= paginate @posts %>
   </div>
 </section>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 30  # 1ページ辺りの項目数
+  # config.max_per_page = 10  # 1ページ辺りの最大数
+  # config.window = 4  # ex 値が2の場合 .. 2 3 (4) 5 6 ..
+  # config.outer_window = 0  # ex 値が2の場合 .. (4) .. 99 100
+  # config.left = 0  # ...になったときの左側の表示数
+  # config.right = 0  # ...になったときの右側の表示数
+  # config.page_method_name = :page  # メソッド名
+  # config.param_name = :page  # ページネーションのパラメーターの名前
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -34,6 +34,12 @@ ja:
     formats:
       default: "%Y/%m/%d"
       datetime: "%Y-%m-%d"
+  pagination:
+    first: "<<"
+    last: ">>"
+    previous: "<"
+    next: ">"
+    truncate: "&hellip;"
   static_pages:
     top:
       create_user: 新規登録


### PR DESCRIPTION
# 概要
各投稿の一覧ページにページネーション機能を実装するため、gemのkaminariを導入する

## パス
`app/controllers/posts_controller.rb`
`app/views/posts/index.html.erb`
`app/views/posts/user_index.html.erb`
`app/views/posts/bookmark.html.erb`
`config/locales/view/ja.yml`

## 実装
- gem kaminariをインストール
- 各コントローラーに30件表示の記述をする
- ページネーションの日本語設定
- 各一覧ページでページネーションを呼び出し、レイアウトを調整

## 確認
- [x] 各一覧ページでページネーション機能が動作しているか
  - [x] 投稿一覧
  - [x] マイコード一覧
  - [x] ブックマーク一覧
- [x] 1ページの表示件数は設定通りになっているか（30件）
- [x] ページネーションのCSSに崩れはないか

## ゴール
各一覧ページでページネーション機能が正常に実装されている