### PR TITLE
検索機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,9 @@ gem 'dotenv-rails'
 # ページネーション
 gem 'kaminari'
 
+# 検索
+gem 'ransack'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,6 +265,10 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rake (13.2.1)
+    ransack (4.2.1)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
+      i18n
     rdoc (6.7.0)
       psych (>= 4.0.0)
     regexp_parser (2.9.2)
@@ -346,6 +350,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.4)
   rails-i18n
+  ransack
   selenium-webdriver
   sprockets-rails
   stimulus-rails

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,7 @@
 class PostsController < ApplicationController
   def index
-    @posts = Post.includes(:user).order(created_at: :desc).page(params[:page])
+    @q = Post.ransack(params[:q])
+    @posts = @q.result(distinct: true).includes(:user).order(created_at: :desc).page(params[:page])
   end
 
   def new
@@ -43,11 +44,13 @@ class PostsController < ApplicationController
   end
 
   def user_index
-    @posts = Post.includes(:user).where(user_id: params[:id]).order(created_at: :desc).page(params[:page])
+    @q = Post.ransack(params[:q])
+    @posts = @q.result(distinct: true).where(user_id: params[:id]).order(created_at: :desc).page(params[:page])
   end
 
   def bookmarks
-    @posts = current_user.bookmark_posts.order(created_at: :desc).page(params[:page])
+    @q = current_user.bookmark_posts.ransack(params[:q])
+    @posts = @q.result(distinct: true).order(created_at: :desc).page(params[:page])
   end
 
   private

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -12,4 +12,14 @@ class Post < ApplicationRecord
   def likes_count
     likes.count
   end
+
+  # titleとdescriptionに対して検索を許可する
+  def self.ransackable_attributes(auth_object = nil)
+    %w[title description]
+  end
+
+  # 関連先のモデルを検索する必要がなければ空の配列を返す
+  def self.ransackable_associations(auth_object = nil)
+    []
+  end
 end

--- a/app/views/posts/_search_form.html.erb
+++ b/app/views/posts/_search_form.html.erb
@@ -1,0 +1,8 @@
+<%= search_form_for q, url: url do |f| %>
+  <div class="flex flex-col justify-center items-center gap-5 mt-20 md:flex-row md:justify-start">
+    <%= f.search_field :title_or_description_cont, class: 'w-full px-4 py-2 text-base md:w-80', placeholder: '検索ワード' %>
+    <div class="w-[120px]">
+      <%= f.submit '検索する', class: 'inline-block rounded max-w-[120px] w-full p-2 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70' %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/posts/bookmarks.html.erb
+++ b/app/views/posts/bookmarks.html.erb
@@ -1,6 +1,9 @@
 <section class="py-10 md:py-20">
   <div class="mx-auto max-w-xl px-5 md:max-w-3xl lg:max-w-5xl">
     <h2 class="text-3xl font-bold text-center md:text-4xl"><%= t('.title') %></h2>
+
+    <%= render 'search_form', q: @q, url: bookmarks_posts_path %>
+
     <% if @posts.present? %>
       <div class="grid grid-cols-1 gap-5 mt-10 md:grid-cols-2 md:gap-10 lg:grid-cols-3">
         <%= render @posts %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,6 +1,9 @@
 <section class="py-10 md:py-20">
   <div class="mx-auto max-w-xl px-5 md:max-w-3xl lg:max-w-5xl">
     <h2 class="text-3xl font-bold text-center md:text-4xl"><%= t('.title') %></h2>
+
+    <%= render 'search_form', q: @q, url: posts_path %>
+
     <% if @posts.present? %>
       <div class="grid grid-cols-1 gap-5 mt-10 md:grid-cols-2 md:gap-10 lg:grid-cols-3">
         <%= render @posts %>

--- a/app/views/posts/user_index.html.erb
+++ b/app/views/posts/user_index.html.erb
@@ -1,6 +1,9 @@
 <section class="py-10 md:py-20">
   <div class="mx-auto max-w-xl px-5 md:max-w-3xl lg:max-w-5xl">
     <h2 class="text-3xl font-bold text-center md:text-4xl"><%= t('.title') %></h2>
+
+    <%= render 'search_form', q: @q, url: user_index_post_path(current_user) %>
+
     <% if @posts.present? %>
       <div class="grid grid-cols-1 gap-5 mt-10 md:grid-cols-2 md:gap-10 lg:grid-cols-3">
         <%= render @posts %>


### PR DESCRIPTION
close #57 

# 概要
gem runsackを使用して投稿の検索機能を実装する

## パス
`app/views/posts/_search_form.html.erb`
`app/views/posts/index.html.erb`

## 実装
- gem runsackを導入
- 投稿一覧ページに検索用のフォームを追加
- 投稿のタイトル・概要が検索できるように設定
- 検索した内容をPostsコントローラーで受け取り、投稿一覧に表示されるように設定

## 確認
- [x] タイトル・概要の検索が出来るようになっているか
- [x] 検索した時、投稿一覧ページに遷移しているか
- [x] 検索した時、適切な投稿一覧が表示されているか

## ゴール
投稿一覧ページで投稿のタイトル・概要で検索が出来るようになる