### PR TITLE
いいねが多い順に投稿を並び替える

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -98,4 +98,9 @@
     background-color: #1995AD;
     color: #fff;
   }
+
+  /* 並び順のボタン */
+  .js-sort-content.is-open {
+    display: block;
+  }
 }

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -2,10 +2,12 @@ class LikesController < ApplicationController
   def create
     @post = Post.find(params[:post_id])
     current_user.like(@post)
+    @post.update_likes_count
   end
 
   def destroy
     @post = Post.find(params[:id])
     current_user.unlike(@post)
+    @post.update_likes_count
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,6 +2,9 @@ class PostsController < ApplicationController
   def index
     @q = Post.ransack(params[:q])
     @posts = @q.result(distinct: true).includes(:user).order(created_at: :desc).page(params[:page])
+    if params[:sort] == 'likes'
+      @posts = @q.result(distinct: true).includes(:user).order(likes_count: :desc, created_at: :desc).page(params[:page])
+    end
   end
 
   def new
@@ -46,11 +49,17 @@ class PostsController < ApplicationController
   def user_index
     @q = Post.ransack(params[:q])
     @posts = @q.result(distinct: true).where(user_id: params[:id]).order(created_at: :desc).page(params[:page])
+    if params[:sort] == 'likes'
+      @posts = @q.result(distinct: true).where(user_id: params[:id]).order(likes_count: :desc, created_at: :desc).page(params[:page])
+    end
   end
 
   def bookmarks
     @q = current_user.bookmark_posts.ransack(params[:q])
     @posts = @q.result(distinct: true).order(created_at: :desc).page(params[:page])
+    if params[:sort] == 'likes'
+      @posts = @q.result(distinct: true).order(likes_count: :desc, created_at: :desc).page(params[:page])
+    end
   end
 
   private

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -5,6 +5,8 @@
 import { application } from "./application"
 import CodeCopyController from "./code_copy_controller"
 import ChangeFormController from "./change_form_controller"
+import indexSortController from "./index_sort_controller"
 
 application.register("code-copy", CodeCopyController)
 application.register("change-form", ChangeFormController)
+application.register("index-sort", indexSortController)

--- a/app/javascript/controllers/index_sort_controller.js
+++ b/app/javascript/controllers/index_sort_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ['sort'];
+
+  toggle() {
+    const sortContent = document.querySelector('.js-sort-content');
+    sortContent.classList.toggle('is-open');
+  }
+
+  remove() {
+    const sortContent = document.querySelector('.js-sort-content');
+    sortContent.classList.remove('is-open');
+  }
+}

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -9,8 +9,8 @@ class Post < ApplicationRecord
 
   mount_uploader :image, ImageUploader
 
-  def likes_count
-    likes.count
+  def update_likes_count
+    self.update(likes_count: self.likes.size)
   end
 
   # titleとdescriptionに対して検索を許可する

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -23,7 +23,7 @@
       </div>
     <% end %>
   <% end %>
-  <% if action_name == 'user_index' %>
+  <% if action_name == 'user_index' || !user_signed_in? %>
     <div class="flex justify-end items-center gap-2 px-5">
       <%= image_tag 'like.png', class: 'w-6' %>
       <span class="text-sm"><%= post.likes_count %></span>

--- a/app/views/posts/_search_form.html.erb
+++ b/app/views/posts/_search_form.html.erb
@@ -1,5 +1,5 @@
 <%= search_form_for q, url: url do |f| %>
-  <div class="flex flex-col justify-center items-center gap-5 mt-20 md:flex-row md:justify-start">
+  <div class="flex flex-col justify-center items-center gap-5 md:flex-row md:justify-start">
     <%= f.search_field :title_or_description_cont, class: 'w-full px-4 py-2 text-base md:w-80', placeholder: '検索ワード' %>
     <div class="w-[120px]">
       <%= f.submit '検索する', class: 'inline-block rounded max-w-[120px] w-full p-2 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70' %>

--- a/app/views/posts/bookmarks.html.erb
+++ b/app/views/posts/bookmarks.html.erb
@@ -2,16 +2,27 @@
   <div class="mx-auto max-w-xl px-5 md:max-w-3xl lg:max-w-5xl">
     <h2 class="text-3xl font-bold text-center md:text-4xl"><%= t('.title') %></h2>
 
-    <%= render 'search_form', q: @q, url: bookmarks_posts_path %>
-
-    <% if @posts.present? %>
-      <div class="grid grid-cols-1 gap-5 mt-10 md:grid-cols-2 md:gap-10 lg:grid-cols-3">
-        <%= render @posts %>
+    <div class="flex justify-start items-center gap-10 mt-20">
+      <%= render 'search_form', q: @q, url: posts_path %>
+      <div class="relative w-[120px]" data-controller="index-sort">
+        <button type="button" data-action="click->index-sort#toggle" class="js-sort-btn inline-block rounded max-w-[120px] w-full p-2 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70">並び順</button>
+        <div class="js-sort-content hidden absolute top-10 left-0 z-10" data-index-sort-target="sort-content">
+          <%= link_to '新着順', bookmarks_posts_path, data: { turbo_frame: 'posts_list', action: 'click->index-sort#remove' }, class: "js-sort-btn inline-block rounded max-w-[120px] w-full p-2 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70" %>
+          <%= link_to 'いいね順', bookmarks_posts_path(sort: 'likes'), data: { turbo_frame: 'posts_list', action: 'click->index-sort#remove' }, class: "js-sort-btn inline-block rounded max-w-[120px] w-full p-2 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70" %>
+        </div>
       </div>
-    <% else %>
-      <p class="mt-10 text-lg text-center md:mt-20"><%= t('.no_post') %></p>
-    <% end %>
+    </div>
 
-    <%= paginate @posts %>
+    <turbo-frame id="posts_list">
+      <% if @posts.present? %>
+        <div class="grid grid-cols-1 gap-5 mt-10 md:grid-cols-2 md:gap-10 lg:grid-cols-3">
+          <%= render @posts %>
+        </div>
+      <% else %>
+        <p class="mt-10 text-lg text-center md:mt-20"><%= t('.no_post') %></p>
+      <% end %>
+      <%= paginate @posts %>
+    </turbo-frame>
+
   </div>
 </section>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -2,16 +2,27 @@
   <div class="mx-auto max-w-xl px-5 md:max-w-3xl lg:max-w-5xl">
     <h2 class="text-3xl font-bold text-center md:text-4xl"><%= t('.title') %></h2>
 
-    <%= render 'search_form', q: @q, url: posts_path %>
-
-    <% if @posts.present? %>
-      <div class="grid grid-cols-1 gap-5 mt-10 md:grid-cols-2 md:gap-10 lg:grid-cols-3">
-        <%= render @posts %>
+    <div class="flex justify-start items-center gap-10 mt-20">
+      <%= render 'search_form', q: @q, url: posts_path %>
+      <div class="relative w-[120px]" data-controller="index-sort">
+        <button type="button" data-action="click->index-sort#toggle" class="js-sort-btn inline-block rounded max-w-[120px] w-full p-2 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70">並び順</button>
+        <div class="js-sort-content hidden absolute top-10 left-0 z-10" data-index-sort-target="sort-content">
+          <%= link_to '新着順', posts_path, data: { turbo_frame: 'posts_list', action: 'click->index-sort#remove' }, class: "js-sort-btn inline-block rounded max-w-[120px] w-full p-2 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70" %>
+          <%= link_to 'いいね順', posts_path(sort: 'likes'), data: { turbo_frame: 'posts_list', action: 'click->index-sort#remove' }, class: "js-sort-btn inline-block rounded max-w-[120px] w-full p-2 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70" %>
+        </div>
       </div>
-    <% else %>
-      <p class="mt-10 text-lg text-center md:mt-20"><%= t('.no_post') %></p>
-    <% end %>
+    </div>
 
-    <%= paginate @posts %>
+    <turbo-frame id="posts_list">
+      <% if @posts.present? %>
+        <div class="grid grid-cols-1 gap-5 mt-10 md:grid-cols-2 md:gap-10 lg:grid-cols-3">
+          <%= render @posts %>
+        </div>
+      <% else %>
+        <p class="mt-10 text-lg text-center md:mt-20"><%= t('.no_post') %></p>
+      <% end %>
+      <%= paginate @posts %>
+    </turbo-frame>
+
   </div>
 </section>

--- a/app/views/posts/user_index.html.erb
+++ b/app/views/posts/user_index.html.erb
@@ -2,15 +2,27 @@
   <div class="mx-auto max-w-xl px-5 md:max-w-3xl lg:max-w-5xl">
     <h2 class="text-3xl font-bold text-center md:text-4xl"><%= t('.title') %></h2>
 
-    <%= render 'search_form', q: @q, url: user_index_post_path(current_user) %>
-
-    <% if @posts.present? %>
-      <div class="grid grid-cols-1 gap-5 mt-10 md:grid-cols-2 md:gap-10 lg:grid-cols-3">
-        <%= render @posts %>
+    <div class="flex justify-start items-center gap-10 mt-20">
+      <%= render 'search_form', q: @q, url: posts_path %>
+      <div class="relative w-[120px]" data-controller="index-sort">
+        <button type="button" data-action="click->index-sort#toggle" class="js-sort-btn inline-block rounded max-w-[120px] w-full p-2 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70">並び順</button>
+        <div class="js-sort-content hidden absolute top-10 left-0 z-10" data-index-sort-target="sort-content">
+          <%= link_to '新着順', user_index_post_path(current_user), data: { turbo_frame: 'posts_list', action: 'click->index-sort#remove' }, class: "js-sort-btn inline-block rounded max-w-[120px] w-full p-2 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70" %>
+          <%= link_to 'いいね順', user_index_post_path(current_user, sort: 'likes'), data: { turbo_frame: 'posts_list', action: 'click->index-sort#remove' }, class: "js-sort-btn inline-block rounded max-w-[120px] w-full p-2 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70" %>
+        </div>
       </div>
-    <% else %>
-      <p class="mt-10 text-lg text-center md:mt-20"><%= t('.no_post') %></p>
-    <% end %>
+    </div>
+
+    <turbo-frame id="posts_list">
+      <% if @posts.present? %>
+        <div class="grid grid-cols-1 gap-5 mt-10 md:grid-cols-2 md:gap-10 lg:grid-cols-3">
+          <%= render @posts %>
+        </div>
+      <% else %>
+        <p class="mt-10 text-lg text-center md:mt-20"><%= t('.no_post') %></p>
+      <% end %>
+      <%= paginate @posts %>
+    </turbo-frame>
 
     <%= paginate @posts %>
   </div>

--- a/db/migrate/20241004012531_add_likes_count_to_posts.rb
+++ b/db/migrate/20241004012531_add_likes_count_to_posts.rb
@@ -1,0 +1,5 @@
+class AddLikesCountToPosts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :posts, :likes_count, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_07_012357) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_04_012531) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -51,6 +51,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_07_012357) do
     t.string "image"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "likes_count", default: 0, null: false
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 


### PR DESCRIPTION
close #121 

# 概要
投稿をいいね順に表示するため、並び替え機能を実装する

## パス
`app/views/posts/index.html.erb`
`app/views/posts/user_index.html.erb`

## 実装
- 投稿一覧とマイ投稿一覧にいいね順に並び替えボタンを追加
- ボタンを押した際、非同期通信で投稿を並び替える

## 確認
- [x] 並び替えボタンの表示崩れはないか
- [x] 投稿一覧・マイ投稿一覧に並び替えボタンがあり、投稿がいいねの多い順に切り替わるか
- [x] 非同期通信で投稿が切り替わっているか

## ゴール
投稿一覧・マイ投稿一覧ページで投稿がいいねの多い順に並び替えることができる