### PR TITLE
プライバシーポリシーページ作成

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,3 +1,5 @@
 class StaticPagesController < ApplicationController
   def top; end
+
+  def privacy; end
 end

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -4,7 +4,7 @@
       <%= link_to t('footer.terms_of_service'), '#', class: 'block p-3 text-white text-center md:inline-block hover:underline' %>
     </li>
     <li>
-      <%= link_to t('footer.privacy_policy'), '#', class: 'block p-3 text-white text-center md:inline-block hover:underline' %>
+      <%= link_to t('footer.privacy_policy'), privacy_path, class: 'block p-3 text-white text-center md:inline-block hover:underline' %>
     </li>
     <li>
       <%= link_to t('footer.contact'), '#', class: 'block p-3 text-white text-center md:inline-block hover:underline' %>

--- a/app/views/static_pages/privacy.html.erb
+++ b/app/views/static_pages/privacy.html.erb
@@ -1,0 +1,63 @@
+<section class="py-10 md:py-20">
+  <div class="mx-auto max-w-xl px-5 md:max-w-3xl lg:max-w-5xl">
+    <h2 class="text-3xl font-bold text-center md:text-4xl"><%= t('.title') %></h2>
+    <div class="grid grid-cols-1 gap-5 mt-10 md:mt-20">
+      <div>
+        <h3 class="text-lg font-bold">お客様から取得する情報</h3>
+        <p class="mt-2 text-base">当社は、お客様から以下の情報を取得します。</p>
+        <ul class="grid grid-cols-1 gap-1 mt-2 pl-5 text-base list-disc">
+          <li>氏名(ニックネームやペンネームも含む)</li>
+          <li>メールアドレス</li>
+          <li>写真や動画</li>
+        </ul>
+      </div>
+      <div>
+        <h3 class="text-lg font-bold">お客様の情報を利用する目的</h3>
+        <p class="mt-2 text-base">当社は、お客様から取得した情報を、以下の目的のために利用します。</p>
+        <ul class="grid grid-cols-1 gap-1 mt-2 pl-5 text-base list-disc">
+          <li>当社サービスに関する登録の受付、お客様の本人確認、認証のため</li>
+          <li>お客様の当社サービスの利用履歴を管理するため</li>
+          <li>利用料金の決済のため</li>
+          <li>当社サービスにおけるお客様の行動履歴を分析し、当社サービスの維持改善に役立てるため</li>
+          <li>当社のサービスに関するご案内をするため</li>
+          <li>お客様からのお問い合わせに対応するため</li>
+          <li>当社の規約や法令に違反する行為に対応するため</li>
+          <li>当社サービスの変更、提供中止、終了、契約解除をご連絡するため</li>
+          <li>当社規約の変更等を通知するため</li>
+          <li>以上の他、当社サービスの提供、維持、保護及び改善のため</li>
+        </ul>
+      </div>
+      <div>
+        <h3 class="text-lg font-bold">安全管理のために講じた措置</h3>
+        <p class="mt-2 text-base">当社が、お客様から取得した情報に関して安全管理のために講じた措置につきましては、末尾記載のお問い合わせ先にご連絡をいただきましたら、法令の定めに従い個別にご回答させていただきます。</p>
+      </div>
+      <div>
+        <h3 class="text-lg font-bold">第三者提供</h3>
+        <p class="mt-2 text-base">当社は、お客様から取得する情報のうち、個人データ（個人情報保護法第１６条第３項）に該当するものついては、あらかじめお客様の同意を得ずに、第三者（日本国外にある者を含みます。）に提供しません。<br>但し、次の場合は除きます。</p>
+        <ul class="grid grid-cols-1 gap-1 mt-2 pl-5 text-base list-disc">
+          <li>個人データの取扱いを外部に委託する場合</li>
+          <li>当社や当社サービスが買収された場合</li>
+          <li>事業パートナーと共同利用する場合（具体的な共同利用がある場合は、その内容を別途公表します。）</li>
+          <li>その他、法律によって合法的に第三者提供が許されている場合</li>
+        </ul>
+      </div>
+      <div>
+        <h3 class="text-lg font-bold">アクセス解析ツール</h3>
+        <p class="mt-2 text-base">当社は、お客様のアクセス解析のために、「Googleアナリティクス」を利用しています。Googleアナリティクスは、トラフィックデータの収集のためにCookieを使用しています。トラフィックデータは匿名で収集されており、個人を特定するものではありません。Cookieを無効にすれば、これらの情報の収集を拒否することができます。詳しくはお使いのブラウザの設定をご確認ください。Googleアナリティクスについて、詳しくは以下からご確認ください。</p>
+        <a href="https://marketingplatform.google.com/about/analytics/terms/jp/" class="inline-block mt-2 text-base text-blue-400 break-all hover:underline" target="_blank">https://marketingplatform.google.com/about/analytics/terms/jp/</a>
+      </div>
+      <div>
+        <h3 class="text-lg font-bold">プライバシーポリシーの変更</h3>
+        <p class="mt-2 text-base">当社は、必要に応じて、このプライバシーポリシーの内容を変更します。この場合、変更後のプライバシーポリシーの施行時期と内容を適切な方法により周知または通知します。</p>
+      </div>
+      <div>
+        <h3 class="text-lg font-bold">お問い合わせ</h3>
+        <p class="mt-2 text-base">お客様の情報の開示、情報の訂正、利用停止、削除をご希望の場合は、以下のお問い合わせフォームにご連絡ください。</p>
+        <%= link_to 'お問い合わせフォーム', '', class: 'inline-block mt-2 text-base text-blue-400 break-all hover:underline' %>
+      </div>
+      <div>
+        <p class="text-base">2024年10月05日 制定</p>
+      </div>
+    </div>
+  </div>
+</section>

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -44,6 +44,8 @@ ja:
     top:
       create_user: 新規登録
       login: ログイン
+    privacy:
+      title: プライバシーポリシー
   users:
     new:
       title: 新規登録

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
     get :likes, on: :collection
   end
   resources :bookmarks, only: %i[create destroy]
+  get "privacy", to: "static_pages#privacy"
 
   get "up" => "rails/health#show", as: :rails_health_check
 end


### PR DESCRIPTION
# 概要
プライバシーポリシーページを作成する

## パス
`app/views/static_pages/privacy.html.erb`

## 実装
- フッターのリンクからプライバシーポリシーページに遷移できるように設定
- 作成したプライバシーポリシーをもとにページを作成

## 確認
- [x] フッターのリンクからプライバシーポリシーページに遷移できるか
- [x] プライバシーポリシーページのテキストに誤字はないか
- [x] CSSの表示崩れはないか

## ゴール
テキスト漏れ・誤字や表示崩れがなくプライバシーポリシーページが表示されている