### PR TITLE
お問い合わせページの作成

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -4,4 +4,6 @@ class StaticPagesController < ApplicationController
   def privacy; end
 
   def terms_of_service; end
+
+  def contact; end
 end

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -7,7 +7,7 @@
       <%= link_to t('footer.privacy_policy'), privacy_path, class: 'block p-3 text-white text-center md:inline-block hover:underline' %>
     </li>
     <li>
-      <%= link_to t('footer.contact'), '#', class: 'block p-3 text-white text-center md:inline-block hover:underline' %>
+      <%= link_to t('footer.contact'), contact_path, class: 'block p-3 text-white text-center md:inline-block hover:underline' %>
     </li>
   </ul>
   <p class="mt-5 text-white font-medium text-center">© 2024 CodeSheet All Rights Reserved.</p>

--- a/app/views/static_pages/contact.html.erb
+++ b/app/views/static_pages/contact.html.erb
@@ -1,0 +1,8 @@
+<section class="py-10 md:py-20">
+  <div class="mx-auto max-w-xl px-5 md:max-w-3xl lg:max-w-5xl">
+    <h2 class="text-3xl font-bold text-center md:text-4xl"><%= t('.title') %></h2>
+  </div>
+  <div class="mt-10 md:mt-20">
+    <iframe src="https://docs.google.com/forms/d/e/1FAIpQLScHpo5PGPzOT2AlN4lax8mKRq0vMs85vWqot0RMpJRJfvmRXQ/viewform?embedded=true" width="640" height="1150" frameborder="0" marginheight="0" marginwidth="0" class="w-full h-[1400px] md:mx-auto md:h-[1150px]">読み込んでいます…</iframe>
+  </div>
+</section>

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -48,6 +48,8 @@ ja:
       title: プライバシーポリシー
     terms_of_service:
       title: 利用規約
+    contact:
+      title: お問い合わせ
   users:
     new:
       title: 新規登録

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
   resources :bookmarks, only: %i[create destroy]
   get "privacy", to: "static_pages#privacy"
   get "terms_of_service", to: "static_pages#terms_of_service"
+  get "contact", to: "static_pages#contact"
 
   get "up" => "rails/health#show", as: :rails_health_check
 end


### PR DESCRIPTION
close #126 

# 概要
お問い合わせページを作成する

## パス
`app/views/static_pages/contact.html.erb`

## 実装
- フッターのリンクからお問い合わせページに遷移できるように設定
- googleフォームの作成
- お問い合わせーページの作成

## 確認
- [x] フッターのリンクからお問い合わせページに遷移できるか
- [x] CSSの表示崩れはないか

## ゴール
表示崩れがなくお問い合わせページが表示されている