### PR TITLE
検索のオートコンプリート機能を実装

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -62,9 +62,22 @@ class PostsController < ApplicationController
     end
   end
 
+  # 追加
+  def search
+    @posts = Post.where("title like ?", "%#{params[:q]}%")
+    respond_to do |format|
+      format.js
+    end
+  end
+
   private
 
   def post_params
     params.require(:post).permit(:title, :description, :image, :image_cache, codes_attributes: [:id, :language, :body, :_destroy])
+  end
+
+
+  def set_post
+    @post = Post.find(params[:id])
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -62,7 +62,6 @@ class PostsController < ApplicationController
     end
   end
 
-  # 追加
   def search
     @posts = Post.where("title like ?", "%#{params[:q]}%")
     respond_to do |format|

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,7 +6,9 @@ import { application } from "./application"
 import CodeCopyController from "./code_copy_controller"
 import ChangeFormController from "./change_form_controller"
 import indexSortController from "./index_sort_controller"
+import { Autocomplete } from 'stimulus-autocomplete'
 
 application.register("code-copy", CodeCopyController)
 application.register("change-form", ChangeFormController)
 application.register("index-sort", indexSortController)
+application.register('autocomplete', Autocomplete)

--- a/app/views/posts/_search_form.html.erb
+++ b/app/views/posts/_search_form.html.erb
@@ -1,6 +1,10 @@
 <%= search_form_for q, url: url do |f| %>
   <div class="flex flex-col justify-center items-center gap-5 md:flex-row md:justify-start">
-    <%= f.search_field :title_or_description_cont, class: 'w-full px-4 py-2 text-base md:w-80', placeholder: '検索ワード' %>
+    <div class="relative" data-controller="autocomplete" data-autocomplete-url-value="/posts/search" role="combobox">
+      <%= f.search_field :title_or_description_cont, data: { autocomplete_target: 'input' }, class: 'w-full px-4 py-2 text-base md:w-80', placeholder: '検索ワード' %>
+      <%= f.hidden_field :title, data: { autocomplete_target: 'hidden' } %>
+      <ul class="bg-white absolute top-[40px]" data-autocomplete-target="results"></ul>
+    </div>
     <div class="w-[120px]">
       <%= f.submit '検索する', class: 'inline-block rounded max-w-[120px] w-full p-2 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70' %>
     </div>

--- a/app/views/posts/search.html.erb
+++ b/app/views/posts/search.html.erb
@@ -1,0 +1,5 @@
+<% @posts.each do |post| %>
+  <li class="w-80 flex items-center gap-x-3.5 py-2 px-3 rounded-md text-sm text-gray-800 hover:bg-blue-200 focus:ring-2 focus:ring-blue-500 dark:text-gray-400 dark:hover:bg-blue-200 dark:hover:text-gray-300" role="option" data-autocomplete-value="<%= post.id %>" data-autocomplete-label="<%= post.title %>">
+    <%= post.title %>
+  </li>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
     resources :codes
     resources :likes, only: %i[create destroy], shallow: true
     get :likes, on: :collection
+    get :search, on: :collection
   end
   resources :bookmarks, only: %i[create destroy]
   get "privacy", to: "static_pages#privacy"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "autoprefixer": "^10.4.19",
     "esbuild": "^0.23.0",
     "postcss": "^8.4.39",
+    "stimulus-autocomplete": "^3.1.0",
     "tailwindcss": "^3.4.6"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -805,6 +805,11 @@ source-map-js@^1.2.0:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.0.tgz#16b809c162517b5b8c3e7dcd315a2a5c2612b2af"
   integrity sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==
 
+stimulus-autocomplete@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/stimulus-autocomplete/-/stimulus-autocomplete-3.1.0.tgz#7c9292706556ed0a87abf60ea2688bf0ea1176a8"
+  integrity sha512-SmVViCdA8yCl99oV2kzllNOqYjx7wruY+1OjAVsDTkZMNFZG5j+SqDKHMYbu+dRFy/SWq/PParzwZHvLAgH+YA==
+
 "string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"


### PR DESCRIPTION
# 概要
検索のオートコンプリート機能を実装する

## パス
`app/controllers/post_controller.rb`
`app/views/posts/_search_form.html.erb`
`app/views/posts/search.html.erb`

## 実装
- yarnでstimulus-autocompleteをインストールし読み込む
- post_controllerにsearchアクションを追加
- 上記のviewファイルにautocomplete機能を実装

## 確認
- [x] 検索の予測はタイトルのみになっているか
- [x] タイトルのリストに表示崩れはないか
- [x] 検索が正常にできるか

## 参考URL
https://qiita.com/Yamamoto-Masaya1122/items/879d6eb540ce4e05cfe5

## ゴール
ユーザーのパスワードが再設定できるようになる