### PR TITLE
投稿の公開・非公開機能

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -103,4 +103,45 @@
   .js-sort-content.is-open {
     display: block;
   }
+
+  /* ラジオボタン */
+  .radio {
+    position: relative;
+    display: block;
+    padding-left: 32px;
+    font-size: 16px;
+    line-height: 1.5;
+    cursor: pointer;
+  }
+
+  .radio::before {
+    position: absolute;
+    top: -1px;
+    left: 0;
+    border: 1px solid #C8C8C8;
+    border-radius: 50%;
+    width: 26px;
+    height: 26px;
+    background-color: #fff;
+    content: "";
+    z-index: 1;
+  }
+
+  .radio::after {
+    display: none;
+    position: absolute;
+    top: 7px;
+    left: 8px;
+    border-radius: 50%;
+    width: 10px;
+    height: 10px;
+    background-color: #1995AD;
+    content: "";
+    z-index: 2;
+  }
+
+  /* ラジオボタンが選択された時 */
+  input[type="radio"]:checked + .radio::after {
+    display: block;
+  }
 }

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,7 +1,7 @@
 class PostsController < ApplicationController
   def index
     @q = Post.ransack(params[:q])
-    @posts = @q.result(distinct: true).includes(:user).order(created_at: :desc).page(params[:page])
+    @posts = @q.result(distinct: true).includes(:user).status_public.order(created_at: :desc).page(params[:page])
     if params[:sort] == 'likes'
       @posts = @q.result(distinct: true).includes(:user).order(likes_count: :desc, created_at: :desc).page(params[:page])
     end
@@ -72,11 +72,6 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:title, :description, :image, :image_cache, codes_attributes: [:id, :language, :body, :_destroy])
-  end
-
-
-  def set_post
-    @post = Post.find(params[:id])
+    params.require(:post).permit(:title, :description, :image, :image_cache, :status, codes_attributes: [:id, :language, :body, :_destroy])
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -24,6 +24,9 @@ class PostsController < ApplicationController
 
   def show
     @post = Post.includes(:codes).find(params[:id])
+    if @post.status_private? && @post.user != current_user
+      redirect_to posts_path, danger: t('defaults.flash_message.cannot_be_accessed')
+    end
   end
 
   def edit

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -5,6 +5,8 @@ class Post < ApplicationRecord
   accepts_nested_attributes_for :codes, allow_destroy: true
   belongs_to :user
 
+  enum status: { public: 0, private: 1 }, _prefix: true
+
   validates :title, presence: true, length: { maximum: 100 }
 
   mount_uploader :image, ImageUploader

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -20,6 +20,20 @@
     <%= image_tag @post.image_url, class: 'w-64 object-contain' %>
   <% end %>
 
+  <div>
+    <label class="inline-block text-base md:text-lg"><%= t('activerecord.attributes.post.status_title') %></label>
+    <div class="flex gap-10 mt-3">
+      <%= f.label :public, for: nil do %>
+        <%= f.radio_button :status, :public, class: 'absolute opacity-0' %>
+        <span class="radio"><%= t('activerecord.attributes.post.status.public') %></span>
+      <% end %>
+      <%= f.label :private, for: nil do %>
+        <%= f.radio_button :status, :private, class: 'absolute opacity-0' %>
+        <span class="radio"><%= t('activerecord.attributes.post.status.private') %></span>
+      <% end %>
+    </div>
+  </div>
+
   <div data-controller="change-form">
     <%= f.fields_for :codes do |c| %>
       <div class="mt-5 md:mt-10 js-code" data-change-form-target="form-code">

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -11,6 +11,10 @@ ja:
         title: タイトル
         description: コード説明
         image: サムネイル
+        status_title: コードの公開・非公開
+        status:
+          public: 公開
+          private: 非公開
       code:
         language: 言語
         body: コード

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -8,6 +8,7 @@ ja:
       updated: "%{item}を更新しました"
       not_updated: "%{item}を更新出来ませんでした"
       destroyed: "%{item}を削除しました"
+      cannot_be_accessed: このページにはアクセスできません
   helper:
     submit:
       create: 登録する

--- a/db/migrate/20241009004533_remove_public_from_posts.rb
+++ b/db/migrate/20241009004533_remove_public_from_posts.rb
@@ -1,0 +1,5 @@
+class RemovePublicFromPosts < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :posts, :public, :boolean
+  end
+end

--- a/db/migrate/20241009004651_add_status_to_posts.rb
+++ b/db/migrate/20241009004651_add_status_to_posts.rb
@@ -1,0 +1,5 @@
+class AddStatusToPosts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :posts, :status, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_04_012531) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_09_004651) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -47,11 +47,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_04_012531) do
     t.bigint "user_id", null: false
     t.string "title", default: "", null: false
     t.text "description", default: ""
-    t.boolean "public"
     t.string "image"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "likes_count", default: 0, null: false
+    t.integer "status", default: 0, null: false
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 


### PR DESCRIPTION
close #138 

# 概要
投稿の非公開機能を実装する

## パス
`app/controllers/post_controller.rb`
`app/models/post.rb`
`app/views/posts/_form.html.erb`

## 実装
- postsテーブルのpublicカラムを削除し、statusカラム(integer)を追加する
- statusカラムにenumを設定
  - 0: public, 1: private
- 新規投稿と編集ページに公開・非公開のラジオボタンを追加
- フォームの日本語化対応
- コントローラーで非公開機能と他のユーザーがアクセスできないように設定

## 確認
- [x] postsテーブルのカラムは正しく設定されているか
- [x] statusカラムのenumは正しく設定されているか
- [x] ラジオフォームのレイアウト崩れはないか
- [x] 非公開にした時、投稿一覧に表示されていないか
- [x] 他のユーザーがアクセスした時、投稿一覧にリダイレクトされているか

## ゴール
投稿の公開・非公開設定が可能になる