### PR TITLE
tagモデルとpost_tagsモデル作成

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,6 +2,8 @@ class Post < ApplicationRecord
   has_many :codes, dependent: :destroy
   has_many :bookmarks, dependent: :destroy
   has_many :likes, dependent: :destroy
+  has_many :post_tags, dependent: :destroy
+  has_many :tags, through: :post_tags
   accepts_nested_attributes_for :codes, allow_destroy: true
   belongs_to :user
 

--- a/app/models/post_tag.rb
+++ b/app/models/post_tag.rb
@@ -1,0 +1,6 @@
+class PostTag < ApplicationRecord
+  belongs_to :post
+  belongs_to :tag
+
+  validates :tag_id, uniqueness: { scope: :post_id }
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,6 @@
+class Tag < ApplicationRecord
+  has_many :post_tags, dependent: :destroy
+  has_many :posts, through: :post_tags
+
+  validates :name, presence: true, uniqueness: true
+end

--- a/db/migrate/20241009121926_create_tags.rb
+++ b/db/migrate/20241009121926_create_tags.rb
@@ -1,0 +1,11 @@
+class CreateTags < ActiveRecord::Migration[7.1]
+  def change
+    create_table :tags do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+
+    add_index :tags, :name, unique: true
+  end
+end

--- a/db/migrate/20241009122055_create_post_tags.rb
+++ b/db/migrate/20241009122055_create_post_tags.rb
@@ -1,0 +1,12 @@
+class CreatePostTags < ActiveRecord::Migration[7.1]
+  def change
+    create_table :post_tags do |t|
+      t.references :post, null: false, foreign_key: true
+      t.references :tag, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :post_tags, %i[post_id tag_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_09_004651) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_09_122055) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -43,6 +43,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_09_004651) do
     t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
+  create_table "post_tags", force: :cascade do |t|
+    t.bigint "post_id", null: false
+    t.bigint "tag_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id", "tag_id"], name: "index_post_tags_on_post_id_and_tag_id", unique: true
+    t.index ["post_id"], name: "index_post_tags_on_post_id"
+    t.index ["tag_id"], name: "index_post_tags_on_tag_id"
+  end
+
   create_table "posts", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "title", default: "", null: false
@@ -53,6 +63,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_09_004651) do
     t.integer "likes_count", default: 0, null: false
     t.integer "status", default: 0, null: false
     t.index ["user_id"], name: "index_posts_on_user_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
   create_table "users", force: :cascade do |t|
@@ -74,5 +91,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_09_004651) do
   add_foreign_key "codes", "posts"
   add_foreign_key "likes", "posts"
   add_foreign_key "likes", "users"
+  add_foreign_key "post_tags", "posts"
+  add_foreign_key "post_tags", "tags"
   add_foreign_key "posts", "users"
 end


### PR DESCRIPTION
close #140 

# 概要
タグ検索機能を実装するため、tagモデル・post_tagモデルを作成する

## パス
`app/models/tag.rb`
`app/models/post_tag.rb`

## attribute
- tag
  - name(string)
- post_tag
  - tag_id
  - post_id

## 制約
- tag
  - name：nullを許容しない

## 確認
- [x] Posts(1)：Post_tags(多)のリレーションが出来ている
- [x] Tags(1)：Post_tags(多)のリレーションが出来ている

## ゴール
db/schema.rbに上記のカラムがあるTags・Post_tagsテーブルが生成されている