### PR TITLE
タグ機能

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -2,5 +2,5 @@ class Tag < ApplicationRecord
   has_many :post_tags, dependent: :destroy
   has_many :posts, through: :post_tags
 
-  validates :name, presence: true, uniqueness: true
+  validates :name, presence: true, uniqueness: true, length: { maximum: 10 }
 end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -34,6 +34,11 @@
     </div>
   </div>
 
+  <div>
+    <%= f.label :tag_names, class: 'inline-block text-base md:text-lg' %><em class="inline-block ml-1 text-base md:text-lg"><%= t("helper.maximum_tag_length") %></em>
+    <%= f.text_field :tag_names, class: 'block mt-2 rounded w-full p-2 bg-white text-base md:px-4 md:py-3', placeholder: ',で区切って入力してください' %>
+  </div>
+
   <div data-controller="change-form">
     <%= f.fields_for :codes do |c| %>
       <div class="mt-5 md:mt-10 js-code" data-change-form-target="form-code">

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -7,8 +7,10 @@
     <% end %>
   <% end %>
   <div class="flex justify-between items-center gap-5 px-5">
-    <span class="inline-block flex-shrink-0 rounded-full px-2 py-1 bg-sub-color text-white text-sm">カテゴリー</span>
-    <time class="text-base font-normal" datetime="<%= l post.created_at, format: :datetime %>"><%= l post.created_at %></time>
+    <% if post.tags.any? %>
+      <%= link_to post.tags.first.name, tag_posts_path(post.tags.first.id), class: 'inline-block flex-shrink-0 rounded-full px-2 py-1 bg-sub-color text-white text-sm duration-300 hover:opacity-70' %>
+    <% end %>
+    <time class="inline-block ml-auto text-base font-normal" datetime="<%= l post.created_at, format: :datetime %>"><%= l post.created_at %></time>
   </div>
   <h3 class="px-5 text-lg font-bold line-clamp-2">
     <%= link_to post_path(post), class: 'hover:underline' do %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,8 +1,7 @@
 <section class="py-10 md:py-20">
   <div class="mx-auto max-w-xl px-5 md:max-w-3xl lg:max-w-5xl">
     <h2 class="text-2xl font-bold md:text-3xl"><%= @post.title %></h2>
-    <div class="flex items-center gap-5 mt-5 md:gap-10 md:mt-10">
-      <span class="inline-block flex-shrink-0 rounded-full px-2 py-1 bg-sub-color text-white text-sm">カテゴリー</span>
+    <div class="mt-5 md:mt-10">
       <time class="text-base font-normal" datetime="<%= l @post.created_at, format: :datetime %>"><%= l @post.created_at %></time>
     </div>
     <p class="mt-5 text-base whitespace-pre-wrap md:mt-10 md:text-lg"><%= @post.description %></p>
@@ -11,6 +10,10 @@
         <%= image_tag @post.image_url, class: 'mx-auto max-w-full max-h-[300px] object-contain' %>
       </div>
     <% end %>
+
+    <div class="flex flex-wrap gap-5 mt-5 md:mt-10">
+      <%= render @post.tags %>
+    </div>
 
     <% @post.codes.each do |code| %>
       <div class="flex flex-col gap-2 code-container" data-controller="code-copy">

--- a/app/views/posts/tags.html.erb
+++ b/app/views/posts/tags.html.erb
@@ -1,0 +1,26 @@
+<section class="py-10 md:py-20">
+  <div class="mx-auto max-w-xl px-5 md:max-w-3xl lg:max-w-5xl">
+    <h2 class="text-3xl font-bold text-center md:text-4xl"><%= t('.title') %></h2>
+
+    <div class="flex flex-col justify-start items-center gap-10 mt-20 md:flex-row">
+      <%= render 'search_form', q: @q, url: posts_path %>
+      <div class="relative w-[120px]" data-controller="index-sort">
+        <button type="button" data-action="click->index-sort#toggle" class="js-sort-btn inline-block rounded max-w-[120px] w-full p-2 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70">並び順</button>
+        <div class="js-sort-content hidden absolute top-10 left-0 z-10" data-index-sort-target="sort-content">
+          <%= link_to '新着順', tag_posts_path, data: { action: 'click->index-sort#remove' }, class: "js-sort-btn inline-block rounded max-w-[120px] w-full p-2 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70" %>
+          <%= link_to 'いいね順', tag_posts_path(sort: 'likes'), data: { action: 'click->index-sort#remove' }, class: "js-sort-btn inline-block rounded max-w-[120px] w-full p-2 bg-sub-color text-white text-base font-bold text-center cursor-pointer duration-300 hover:opacity-70" %>
+        </div>
+      </div>
+    </div>
+
+    <% if @posts.present? %>
+      <div class="grid grid-cols-1 gap-5 mt-10 md:grid-cols-2 md:gap-10 lg:grid-cols-3">
+        <%= render @posts %>
+      </div>
+    <% else %>
+      <p class="mt-10 text-lg text-center md:mt-20"><%= t('.no_post') %></p>
+    <% end %>
+    <%= paginate @posts %>
+
+  </div>
+</section>

--- a/app/views/tags/_tag.html.erb
+++ b/app/views/tags/_tag.html.erb
@@ -1,0 +1,1 @@
+<%= link_to tag.name, tag_posts_path(tag.id), class: 'inline-block flex-shrink-0 rounded-full px-2 py-1 bg-sub-color text-white text-sm duration-300 hover:opacity-70' %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -15,6 +15,7 @@ ja:
         status:
           public: 公開
           private: 非公開
+        tag_names: タグ
       code:
         language: 言語
         body: コード

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -17,6 +17,7 @@ ja:
       edit: 編集する
       destroy: 削除する
       copy: コードコピー
+    maximum_tag_length: (10文字以内)
   header:
     title: CodeSheet
     login: ログイン
@@ -74,3 +75,5 @@ ja:
     bookmarks:
       title: ブックマーク一覧
       no_post: ブックマークされた投稿がありません
+    tags:
+      title: コード一覧

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
     end
     collection do
       get :bookmarks
+      get 'tags/:id', action: :tags, as: :tag
     end
 
     resources :codes


### PR DESCRIPTION
close #142 

# 概要
タグの保存とタグ検索機能を実装する

## 実装
- タグに10文字以内のバリデーションを追記
- タグ用のルーティングを追加
- タグ一覧のアクションを追加
- 各一覧でN＋1が起きないように設定
- タグ用のフォームを追加
- 各ページのレイアウト作成

## 確認
- [x] タグのフォームに10文字以上入力した時エラーが出るか
- [x] タグを複数入力した時正常に保存されているか
- [x] 一覧のタグ、詳細のタグリンクから、それぞれ関連したタグ一覧ページに遷移するか
- [x] タグ一覧ページで新着順・いいね順の並び替えは正常に動作するか
- [x] 各ページで表示崩れはないか

## ゴール
新規投稿や投稿編集でタグが複数保存できる。
投稿一覧の各投稿に登録された最初のタグが表示されており、タグ一覧のリンクが設定してある。
詳細に登録されたタグ一覧が表示されている。